### PR TITLE
Implement FastAPI app with database models

### DIFF
--- a/database.py
+++ b/database.py
@@ -1,0 +1,21 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./annotaria.db")
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,77 @@
+import os
+from pathlib import Path
+from typing import List
+
+from fastapi import FastAPI, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from database import Base, engine, get_db
+import models
+import schemas
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+
+IMAGE_DIR = Path(os.getenv("IMAGE_DIR", "./image_data"))
+IMAGE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+@app.get("/images", response_model=List[schemas.Image])
+def read_images(db: Session = Depends(get_db)):
+    for file in IMAGE_DIR.iterdir():
+        if file.is_file():
+            existing = db.query(models.Image).filter_by(filename=file.name).first()
+            if not existing:
+                db_image = models.Image(filename=file.name, path=str(file))
+                db.add(db_image)
+    db.commit()
+    return db.query(models.Image).all()
+
+
+@app.post("/questions/", response_model=schemas.Question)
+def create_question(question: schemas.QuestionCreate, db: Session = Depends(get_db)):
+    db_question = models.Question(question_text=question.question_text)
+    db.add(db_question)
+    db.commit()
+    db.refresh(db_question)
+    return db_question
+
+
+@app.get("/questions/", response_model=List[schemas.Question])
+def list_questions(db: Session = Depends(get_db)):
+    return db.query(models.Question).all()
+
+
+@app.post("/questions/{question_id}/options/", response_model=schemas.Option)
+def create_option(question_id: int, option: schemas.OptionCreate, db: Session = Depends(get_db)):
+    if not db.query(models.Question).filter_by(id=question_id).first():
+        raise HTTPException(status_code=404, detail="Question not found")
+    db_option = models.Option(question_id=question_id, option_text=option.option_text)
+    db.add(db_option)
+    db.commit()
+    db.refresh(db_option)
+    return db_option
+
+
+@app.get("/questions/{question_id}/options/", response_model=List[schemas.Option])
+def list_options(question_id: int, db: Session = Depends(get_db)):
+    return db.query(models.Option).filter_by(question_id=question_id).all()
+
+
+@app.post("/answers/", response_model=schemas.Answer)
+def create_answer(answer: schemas.AnswerCreate, db: Session = Depends(get_db)):
+    db_answer = models.Answer(**answer.dict())
+    db.add(db_answer)
+    db.commit()
+    db.refresh(db_answer)
+    return db_answer
+
+
+@app.post("/annotations/", response_model=schemas.Annotation)
+def create_annotation(annotation: schemas.AnnotationCreate, db: Session = Depends(get_db)):
+    db_annotation = models.Annotation(**annotation.dict())
+    db.add(db_annotation)
+    db.commit()
+    db.refresh(db_annotation)
+    return db_annotation

--- a/models.py
+++ b/models.py
@@ -1,0 +1,87 @@
+from sqlalchemy import Column, Integer, String, Float, Text, ForeignKey, DateTime
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from database import Base
+
+
+class Image(Base):
+    __tablename__ = "images"
+
+    id = Column(Integer, primary_key=True, index=True)
+    filename = Column(String, unique=True, nullable=False)
+    path = Column(String, nullable=False)
+    uploaded_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    exif_datetime = Column(String)
+    exif_gps_lat = Column(Float)
+    exif_gps_lon = Column(Float)
+    exif_gps_alt = Column(Float)
+    exif_camera_make = Column(String)
+    exif_camera_model = Column(String)
+    exif_lens_model = Column(String)
+    exif_focal_length = Column(Float)
+    exif_aperture = Column(Float)
+    exif_iso = Column(Integer)
+    exif_shutter_speed = Column(String)
+    exif_orientation = Column(String)
+    exif_image_width = Column(Integer)
+    exif_image_height = Column(Integer)
+    exif_drone_model = Column(String)
+    exif_flight_id = Column(String)
+    exif_pitch = Column(Float)
+    exif_roll = Column(Float)
+    exif_yaw = Column(Float)
+
+    answers = relationship("Answer", back_populates="image")
+    annotations = relationship("Annotation", back_populates="image")
+
+
+class Question(Base):
+    __tablename__ = "questions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    question_text = Column(Text, nullable=False)
+
+    options = relationship("Option", back_populates="question")
+    answers = relationship("Answer", back_populates="question")
+
+
+class Option(Base):
+    __tablename__ = "options"
+
+    id = Column(Integer, primary_key=True, index=True)
+    question_id = Column(Integer, ForeignKey("questions.id", ondelete="CASCADE"), nullable=False)
+    option_text = Column(Text, nullable=False)
+
+    question = relationship("Question", back_populates="options")
+    answers = relationship("Answer", back_populates="selected_option")
+
+
+class Answer(Base):
+    __tablename__ = "answers"
+
+    id = Column(Integer, primary_key=True, index=True)
+    image_id = Column(Integer, ForeignKey("images.id"), nullable=False)
+    question_id = Column(Integer, ForeignKey("questions.id"), nullable=False)
+    selected_option_id = Column(Integer, ForeignKey("options.id"), nullable=False)
+    answered_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    image = relationship("Image", back_populates="answers")
+    question = relationship("Question", back_populates="answers")
+    selected_option = relationship("Option", back_populates="answers")
+
+
+class Annotation(Base):
+    __tablename__ = "annotations"
+
+    id = Column(Integer, primary_key=True, index=True)
+    image_id = Column(Integer, ForeignKey("images.id"), nullable=False)
+    label = Column(String, nullable=False)
+    x = Column(Float, nullable=False)
+    y = Column(Float, nullable=False)
+    width = Column(Float, nullable=False)
+    height = Column(Float, nullable=False)
+    annotated_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    image = relationship("Image", back_populates="annotations")

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -1,0 +1,82 @@
+from datetime import datetime
+from typing import List
+from pydantic import BaseModel
+
+
+class Image(BaseModel):
+    id: int
+    filename: str
+    path: str
+
+    class Config:
+        orm_mode = True
+
+
+class QuestionBase(BaseModel):
+    question_text: str
+
+
+class QuestionCreate(QuestionBase):
+    pass
+
+
+class Question(QuestionBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class OptionBase(BaseModel):
+    option_text: str
+
+
+class OptionCreate(OptionBase):
+    pass
+
+
+class Option(OptionBase):
+    id: int
+    question_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class AnswerBase(BaseModel):
+    image_id: int
+    question_id: int
+    selected_option_id: int
+
+
+class AnswerCreate(AnswerBase):
+    pass
+
+
+class Answer(AnswerBase):
+    id: int
+    answered_at: datetime | None = None
+
+    class Config:
+        orm_mode = True
+
+
+class AnnotationBase(BaseModel):
+    image_id: int
+    label: str
+    x: float
+    y: float
+    width: float
+    height: float
+
+
+class AnnotationCreate(AnnotationBase):
+    pass
+
+
+class Annotation(AnnotationBase):
+    id: int
+    annotated_at: datetime | None = None
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- set up SQLAlchemy engine and session
- define models for images, questions, options, answers, annotations
- add FastAPI endpoints for images, questions, options, answers, annotations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e287d469c832a84622860e94c080d