### PR TITLE
Implement full REST API

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 from typing import List
 
-from fastapi import FastAPI, Depends, HTTPException
+from fastapi import FastAPI, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from database import Base, engine, get_db
@@ -38,6 +38,27 @@ def create_question(question: schemas.QuestionCreate, db: Session = Depends(get_
     return db_question
 
 
+@app.put("/questions/{question_id}", response_model=schemas.Question)
+def update_question(question_id: int, question: schemas.QuestionCreate, db: Session = Depends(get_db)):
+    db_question = db.query(models.Question).filter_by(id=question_id).first()
+    if not db_question:
+        raise HTTPException(status_code=404, detail="Question not found")
+    db_question.question_text = question.question_text
+    db.commit()
+    db.refresh(db_question)
+    return db_question
+
+
+@app.delete("/questions/{question_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_question(question_id: int, db: Session = Depends(get_db)):
+    db_question = db.query(models.Question).filter_by(id=question_id).first()
+    if not db_question:
+        raise HTTPException(status_code=404, detail="Question not found")
+    db.delete(db_question)
+    db.commit()
+    return None
+
+
 @app.get("/questions/", response_model=List[schemas.Question])
 def list_questions(db: Session = Depends(get_db)):
     return db.query(models.Question).all()
@@ -54,6 +75,27 @@ def create_option(question_id: int, option: schemas.OptionCreate, db: Session = 
     return db_option
 
 
+@app.put("/options/{option_id}", response_model=schemas.Option)
+def update_option(option_id: int, option: schemas.OptionCreate, db: Session = Depends(get_db)):
+    db_option = db.query(models.Option).filter_by(id=option_id).first()
+    if not db_option:
+        raise HTTPException(status_code=404, detail="Option not found")
+    db_option.option_text = option.option_text
+    db.commit()
+    db.refresh(db_option)
+    return db_option
+
+
+@app.delete("/options/{option_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_option(option_id: int, db: Session = Depends(get_db)):
+    db_option = db.query(models.Option).filter_by(id=option_id).first()
+    if not db_option:
+        raise HTTPException(status_code=404, detail="Option not found")
+    db.delete(db_option)
+    db.commit()
+    return None
+
+
 @app.get("/questions/{question_id}/options/", response_model=List[schemas.Option])
 def list_options(question_id: int, db: Session = Depends(get_db)):
     return db.query(models.Option).filter_by(question_id=question_id).all()
@@ -68,6 +110,11 @@ def create_answer(answer: schemas.AnswerCreate, db: Session = Depends(get_db)):
     return db_answer
 
 
+@app.get("/answers/{image_id}", response_model=List[schemas.Answer])
+def list_answers(image_id: int, db: Session = Depends(get_db)):
+    return db.query(models.Answer).filter_by(image_id=image_id).all()
+
+
 @app.post("/annotations/", response_model=schemas.Annotation)
 def create_annotation(annotation: schemas.AnnotationCreate, db: Session = Depends(get_db)):
     db_annotation = models.Annotation(**annotation.dict())
@@ -75,3 +122,8 @@ def create_annotation(annotation: schemas.AnnotationCreate, db: Session = Depend
     db.commit()
     db.refresh(db_annotation)
     return db_annotation
+
+
+@app.get("/annotations/{image_id}", response_model=List[schemas.Annotation])
+def list_annotations(image_id: int, db: Session = Depends(get_db)):
+    return db.query(models.Annotation).filter_by(image_id=image_id).all()


### PR DESCRIPTION
## Summary
- Add update and delete endpoints for questions and options
- Add listing endpoints for answers and annotations by image ID
- Import FastAPI status codes utility

## Testing
- `python -m py_compile main.py models.py database.py schemas/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e32607850832a83aca940c5e0feb2