### PR TITLE
Add update and delete annotation endpoints

### DIFF
--- a/docs/API_REST.md
+++ b/docs/API_REST.md
@@ -154,13 +154,53 @@ Salva un’annotazione su un'immagine selezionata (area rettangolare + label).
 }
 ```
 
+### `GET /annotations/{image_id}`
+Restituisce tutte le annotazioni associate a una determinata immagine.
+
+**Response 200 OK**
+```json
+[
+  {
+    "id": 14,
+    "image_id": 1,
+    "label": "foglia danneggiata",
+    "x": 120.5,
+    "y": 80.2,
+    "width": 50,
+    "height": 30,
+    "annotated_at": "2025-08-01T15:14:00"
+  }
+]
+```
+
+### `PUT /annotations/{annotation_id}`
+Aggiorna un'annotazione esistente. Solo i campi forniti nel body vengono modificati.
+
+**Request Body**
+```json
+{
+  "label": "foglia sana",
+  "x": 130.0
+}
+```
+
+**Response 200 OK**
+```json
+{
+  "id": 14,
+  "image_id": 1,
+  "label": "foglia sana",
+  "x": 130.0,
+  "y": 80.2,
+  "width": 50,
+  "height": 30,
+  "annotated_at": "2025-08-01T15:14:00"
+}
+```
+
+### `DELETE /annotations/{annotation_id}`
+Elimina un'annotazione esistente.
+
+**Response 204 No Content**
+
 ---
-
-## 🛠️ Endpoints in sviluppo
-
-- `PUT /questions/{id}` – Modifica una domanda
-- `DELETE /questions/{id}` – Elimina una domanda
-- `PUT /options/{id}` – Modifica un’opzione
-- `DELETE /options/{id}` – Elimina un’opzione
-- `GET /answers/{image_id}` – Tutte le risposte per un'immagine
-- `GET /annotations/{image_id}` – Tutte le annotazioni per immagine

--- a/main.py
+++ b/main.py
@@ -127,3 +127,25 @@ def create_annotation(annotation: schemas.AnnotationCreate, db: Session = Depend
 @app.get("/annotations/{image_id}", response_model=List[schemas.Annotation])
 def list_annotations(image_id: int, db: Session = Depends(get_db)):
     return db.query(models.Annotation).filter_by(image_id=image_id).all()
+
+
+@app.put("/annotations/{annotation_id}", response_model=schemas.Annotation)
+def update_annotation(annotation_id: int, annotation: schemas.AnnotationUpdate, db: Session = Depends(get_db)):
+    db_annotation = db.query(models.Annotation).filter_by(id=annotation_id).first()
+    if not db_annotation:
+        raise HTTPException(status_code=404, detail="Annotation not found")
+    for field, value in annotation.dict(exclude_unset=True).items():
+        setattr(db_annotation, field, value)
+    db.commit()
+    db.refresh(db_annotation)
+    return db_annotation
+
+
+@app.delete("/annotations/{annotation_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_annotation(annotation_id: int, db: Session = Depends(get_db)):
+    db_annotation = db.query(models.Annotation).filter_by(id=annotation_id).first()
+    if not db_annotation:
+        raise HTTPException(status_code=404, detail="Annotation not found")
+    db.delete(db_annotation)
+    db.commit()
+    return None

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -74,6 +74,15 @@ class AnnotationCreate(AnnotationBase):
     pass
 
 
+class AnnotationUpdate(BaseModel):
+    image_id: int | None = None
+    label: str | None = None
+    x: float | None = None
+    y: float | None = None
+    width: float | None = None
+    height: float | None = None
+
+
 class Annotation(AnnotationBase):
     id: int
     annotated_at: datetime | None = None


### PR DESCRIPTION
## Summary
- add Pydantic model `AnnotationUpdate` for partial updates
- implement `PUT /annotations/{annotation_id}` and `DELETE /annotations/{annotation_id}` routes
- expand API docs with annotation get, update and delete endpoints

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e356e34f8832a83d32b6bec1c459e