### PR TITLE
Add image upload endpoint with EXIF extraction

### DIFF
--- a/docs/API_REST.md
+++ b/docs/API_REST.md
@@ -23,6 +23,25 @@ Restituisce l’elenco delle immagini disponibili nella directory configurata e 
 ]
 ```
 
+### `POST /images/upload`
+Carica una nuova immagine salvandola sul server ed estrae i metadati EXIF.
+
+**Request** `multipart/form-data`
+```
+file=<binary>
+```
+
+**Response 201 Created**
+```json
+{
+  "id": 2,
+  "filename": "nuova.jpg",
+  "path": "./image_data/nuova.jpg",
+  "exif_camera_model": "DJI Mavic Air 2",
+  "exif_datetime": "2025-07-31 14:30:00"
+}
+```
+
 ---
 
 ## ❓ DOMANDE E OPZIONI

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -12,6 +12,28 @@ class Image(BaseModel):
         orm_mode = True
 
 
+class ImageDetail(Image):
+    exif_datetime: str | None = None
+    exif_gps_lat: float | None = None
+    exif_gps_lon: float | None = None
+    exif_gps_alt: float | None = None
+    exif_camera_make: str | None = None
+    exif_camera_model: str | None = None
+    exif_lens_model: str | None = None
+    exif_focal_length: float | None = None
+    exif_aperture: float | None = None
+    exif_iso: int | None = None
+    exif_shutter_speed: str | None = None
+    exif_orientation: str | None = None
+    exif_image_width: int | None = None
+    exif_image_height: int | None = None
+    exif_drone_model: str | None = None
+    exif_flight_id: str | None = None
+    exif_pitch: float | None = None
+    exif_roll: float | None = None
+    exif_yaw: float | None = None
+
+
 class QuestionBase(BaseModel):
     question_text: str
 


### PR DESCRIPTION
## Summary
- add EXIF extraction helpers and database registration utilities
- implement `/images/upload` endpoint for saving images and metadata
- document image upload endpoint and extend image schema with EXIF fields

## Testing
- `python -m py_compile main.py schemas/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e3697037c832a806f4c587fcda32c