### PR TITLE
Add option, answer and annotation endpoints

### DIFF
--- a/docs/API_Examples.md
+++ b/docs/API_Examples.md
@@ -28,10 +28,10 @@ curl -X POST http://localhost:8000/questions/ \
 
 ## ➕ Aggiunta di opzioni a una domanda
 
-### `POST /questions/1/options/`
+### `POST /questions/1/options`
 
 ```bash
-curl -X POST http://localhost:8000/questions/1/options/ \
+curl -X POST http://localhost:8000/questions/1/options \
   -H "Content-Type: application/json" \
   -d '{"option_text": "Secco"}'
 ```
@@ -81,10 +81,10 @@ curl -X POST http://localhost:8000/annotations/ \
 curl http://localhost:8000/questions/
 ```
 
-### `GET /questions/1/options/`
+### `GET /questions/1/options`
 
 ```bash
-curl http://localhost:8000/questions/1/options/
+curl http://localhost:8000/questions/1/options
 ```
 
 ---

--- a/docs/API_REST.md
+++ b/docs/API_REST.md
@@ -77,7 +77,7 @@ Crea una nuova domanda.
 }
 ```
 
-### `GET /questions/{question_id}/options/`
+### `GET /questions/{question_id}/options`
 Restituisce tutte le opzioni associate a una domanda.
 
 **Response 200 OK**
@@ -94,7 +94,7 @@ Restituisce tutte le opzioni associate a una domanda.
 ]
 ```
 
-### `POST /questions/{question_id}/options/`
+### `POST /questions/{question_id}/options`
 Aggiunge una nuova opzione a una domanda esistente.
 
 **Request Body**


### PR DESCRIPTION
## Summary
- import Option, Answer and Annotation models and their schemas
- add endpoints for question options, answers and annotations
- document updated option, answer and annotation APIs

## Testing
- `python -m py_compile main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68906b76f8f8832a8a660a305189dc6d