### PR TITLE
Implement basic user authentication with OAuth2

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,8 +4,12 @@ from pathlib import Path
 from typing import List
 
 from fastapi import FastAPI, Depends, HTTPException, status, UploadFile, File
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
+from passlib.context import CryptContext
+from jose import JWTError, jwt
 from PIL import Image as PILImage, ExifTags
+from datetime import datetime, timedelta
 
 from database import Base, engine, get_db
 from models import (
@@ -14,6 +18,7 @@ from models import (
     Option as OptionModel,
     Answer as AnswerModel,
     Annotation as AnnotationModel,
+    User as UserModel,
 )
 from schemas import (
     Image as ImageSchema,
@@ -28,6 +33,7 @@ from schemas import (
     AnnotationCreate,
     AnnotationUpdate,
 )
+from schemas.user import UserCreate, UserResponse, Token
 
 Base.metadata.create_all(bind=engine)
 
@@ -35,6 +41,51 @@ app = FastAPI()
 
 IMAGE_DIR = Path(os.getenv("IMAGE_DIR", "./image_data"))
 IMAGE_DIR.mkdir(parents=True, exist_ok=True)
+
+SECRET_KEY = os.getenv("SECRET_KEY", "secret")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (
+        expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    )
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def get_current_user(
+    token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)
+):
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str | None = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    user = db.query(UserModel).filter_by(username=username).first()
+    if user is None:
+        raise credentials_exception
+    return user
 
 
 def _ratio_to_float(value):
@@ -121,6 +172,37 @@ def register_image(path: Path, db: Session):
     db.commit()
     db.refresh(db_image)
     return db_image
+
+
+@app.post("/users/", response_model=UserResponse)
+def create_user(user: UserCreate, db: Session = Depends(get_db)):
+    existing_user = db.query(UserModel).filter_by(username=user.username).first()
+    if existing_user:
+        raise HTTPException(status_code=400, detail="Username already registered")
+    db_user = UserModel(
+        username=user.username, hashed_password=get_password_hash(user.password)
+    )
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+@app.post("/token", response_model=Token)
+def login_for_access_token(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    db: Session = Depends(get_db),
+):
+    user = db.query(UserModel).filter_by(username=form_data.username).first()
+    if not user or not verify_password(form_data.password, user.hashed_password):
+        raise HTTPException(status_code=400, detail="Incorrect username or password")
+    access_token = create_access_token(data={"sub": user.username})
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+@app.get("/users/me", response_model=UserResponse)
+def read_users_me(current_user: UserModel = Depends(get_current_user)):
+    return current_user
 
 
 @app.get("/images", response_model=List[ImageSchema])

--- a/models.py
+++ b/models.py
@@ -5,6 +5,14 @@ from sqlalchemy.sql import func
 from database import Base
 
 
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True, nullable=False)
+    hashed_password = Column(String, nullable=False)
+
+
 class Image(Base):
     __tablename__ = "images"
 

--- a/schemas/user.py
+++ b/schemas/user.py
@@ -1,0 +1,30 @@
+from pydantic import BaseModel
+
+
+class UserBase(BaseModel):
+    username: str
+
+
+class UserCreate(UserBase):
+    password: str
+
+
+class UserLogin(BaseModel):
+    username: str
+    password: str
+
+
+class UserResponse(UserBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+
+
+class TokenData(BaseModel):
+    username: str | None = None


### PR DESCRIPTION
## Summary
- add `User` SQLAlchemy model
- create user schemas for registration, login and tokens
- implement registration, JWT login and current user dependency

## Testing
- `pytest`
- `python - <<'PY'
import main
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_689075ad65ec832ab8f5f1e06c718ef2