### PR TITLE
Link answers and annotations to authenticated users

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,8 +27,9 @@ from schemas import (
     QuestionCreate,
     Option as OptionSchema,
     OptionCreate,
-    Answer as AnswerSchema,
-    AnswerCreate,
+)
+from schemas.answer import Answer as AnswerSchema, AnswerCreate
+from schemas.annotation import (
     Annotation as AnnotationSchema,
     AnnotationCreate,
     AnnotationUpdate,
@@ -304,8 +305,12 @@ def list_options(question_id: int, db: Session = Depends(get_db)):
 
 
 @app.post("/answers/", response_model=AnswerSchema)
-def create_answer(answer: AnswerCreate, db: Session = Depends(get_db)):
-    db_answer = AnswerModel(**answer.dict())
+def create_answer(
+    answer: AnswerCreate,
+    db: Session = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    db_answer = AnswerModel(**answer.dict(), user_id=current_user.id)
     db.add(db_answer)
     db.commit()
     db.refresh(db_answer)
@@ -313,13 +318,25 @@ def create_answer(answer: AnswerCreate, db: Session = Depends(get_db)):
 
 
 @app.get("/answers/{image_id}", response_model=List[AnswerSchema])
-def list_answers(image_id: int, db: Session = Depends(get_db)):
-    return db.query(AnswerModel).filter_by(image_id=image_id).all()
+def list_answers(
+    image_id: int,
+    db: Session = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    return (
+        db.query(AnswerModel)
+        .filter_by(image_id=image_id, user_id=current_user.id)
+        .all()
+    )
 
 
 @app.post("/annotations/", response_model=AnnotationSchema)
-def create_annotation(annotation: AnnotationCreate, db: Session = Depends(get_db)):
-    db_annotation = AnnotationModel(**annotation.dict())
+def create_annotation(
+    annotation: AnnotationCreate,
+    db: Session = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    db_annotation = AnnotationModel(**annotation.dict(), user_id=current_user.id)
     db.add(db_annotation)
     db.commit()
     db.refresh(db_annotation)
@@ -327,8 +344,16 @@ def create_annotation(annotation: AnnotationCreate, db: Session = Depends(get_db
 
 
 @app.get("/annotations/{image_id}", response_model=List[AnnotationSchema])
-def list_annotations(image_id: int, db: Session = Depends(get_db)):
-    return db.query(AnnotationModel).filter_by(image_id=image_id).all()
+def list_annotations(
+    image_id: int,
+    db: Session = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    return (
+        db.query(AnnotationModel)
+        .filter_by(image_id=image_id, user_id=current_user.id)
+        .all()
+    )
 
 
 @app.put("/annotations/{annotation_id}", response_model=AnnotationSchema)

--- a/models.py
+++ b/models.py
@@ -12,6 +12,9 @@ class User(Base):
     username = Column(String, unique=True, index=True, nullable=False)
     hashed_password = Column(String, nullable=False)
 
+    answers = relationship("Answer", back_populates="user")
+    annotations = relationship("Annotation", back_populates="user")
+
 
 class Image(Base):
     __tablename__ = "images"
@@ -73,11 +76,13 @@ class Answer(Base):
     image_id = Column(Integer, ForeignKey("images.id"), nullable=False)
     question_id = Column(Integer, ForeignKey("questions.id"), nullable=False)
     selected_option_id = Column(Integer, ForeignKey("options.id"), nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     answered_at = Column(DateTime(timezone=True), server_default=func.now())
 
     image = relationship("Image", back_populates="answers")
     question = relationship("Question", back_populates="answers")
     selected_option = relationship("Option", back_populates="answers")
+    user = relationship("User", back_populates="answers")
 
 
 class Annotation(Base):
@@ -90,6 +95,8 @@ class Annotation(Base):
     y = Column(Float, nullable=False)
     width = Column(Float, nullable=False)
     height = Column(Float, nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     annotated_at = Column(DateTime(timezone=True), server_default=func.now())
 
     image = relationship("Image", back_populates="annotations")
+    user = relationship("User", back_populates="annotations")

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-from typing import List
 from pydantic import BaseModel
 
 
@@ -65,49 +63,5 @@ class Option(OptionBase):
         orm_mode = True
 
 
-class AnswerBase(BaseModel):
-    image_id: int
-    question_id: int
-    selected_option_id: int
-
-
-class AnswerCreate(AnswerBase):
-    pass
-
-
-class Answer(AnswerBase):
-    id: int
-    answered_at: datetime | None = None
-
-    class Config:
-        orm_mode = True
-
-
-class AnnotationBase(BaseModel):
-    image_id: int
-    label: str
-    x: float
-    y: float
-    width: float
-    height: float
-
-
-class AnnotationCreate(AnnotationBase):
-    pass
-
-
-class AnnotationUpdate(BaseModel):
-    image_id: int | None = None
-    label: str | None = None
-    x: float | None = None
-    y: float | None = None
-    width: float | None = None
-    height: float | None = None
-
-
-class Annotation(AnnotationBase):
-    id: int
-    annotated_at: datetime | None = None
-
-    class Config:
-        orm_mode = True
+from .answer import Answer, AnswerCreate
+from .annotation import Annotation, AnnotationCreate, AnnotationUpdate

--- a/schemas/annotation.py
+++ b/schemas/annotation.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class AnnotationBase(BaseModel):
+    image_id: int
+    label: str
+    x: float
+    y: float
+    width: float
+    height: float
+
+
+class AnnotationCreate(AnnotationBase):
+    pass
+
+
+class AnnotationUpdate(BaseModel):
+    image_id: int | None = None
+    label: str | None = None
+    x: float | None = None
+    y: float | None = None
+    width: float | None = None
+    height: float | None = None
+
+
+class Annotation(AnnotationBase):
+    id: int
+    user_id: int
+    annotated_at: datetime | None = None
+
+    class Config:
+        orm_mode = True

--- a/schemas/answer.py
+++ b/schemas/answer.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class AnswerBase(BaseModel):
+    image_id: int
+    question_id: int
+    selected_option_id: int
+
+
+class AnswerCreate(AnswerBase):
+    pass
+
+
+class Answer(AnswerBase):
+    id: int
+    user_id: int
+    answered_at: datetime | None = None
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- Associate answers and annotations with users via `user_id` and back-populated relationships.
- Include `user_id` in Pydantic schemas for answers and annotations.
- Require authentication for creating and listing answers/annotations, binding records to `current_user`.

## Testing
- `python -m py_compile models.py schemas/answer.py`
- `python -m py_compile schemas/annotation.py schemas/__init__.py main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6890784e8b00832a85b7a5a2e092dca9