### PR TITLE
docs: document user auth flow

### DIFF
--- a/docs/API_REST.md
+++ b/docs/API_REST.md
@@ -5,6 +5,47 @@ Prefisso base: `http://localhost:8000/`
 
 ---
 
+## 👤 AUTENTICAZIONE
+
+### `POST /users/`
+Registra un nuovo utente.
+
+**Request Body**
+```json
+{
+  "username": "alice",
+  "password": "segreta"
+}
+```
+
+**Response 201 Created**
+```json
+{
+  "id": 1,
+  "username": "alice"
+}
+```
+
+### `POST /token`
+Esegue il login e restituisce un token JWT da usare nelle richieste protette.
+
+**Request Body** `application/x-www-form-urlencoded`
+```
+username=<username>&password=<password>
+```
+
+**Response 200 OK**
+```json
+{
+  "access_token": "<token>",
+  "token_type": "bearer"
+}
+```
+
+Per le rotte che richiedono autenticazione inviare l'header:
+
+`Authorization: Bearer <token>`
+
 ## 📁 IMMAGINI
 
 ### `GET /images`
@@ -117,8 +158,10 @@ Aggiunge una nuova opzione a una domanda esistente.
 
 ## 📝 RISPOSTE
 
+Richiede autenticazione; l'utente associato viene determinato dal token presente nell'header `Authorization: Bearer <token>`.
+
 ### `POST /answers/`
-Registra la risposta fornita da un utente per una determinata immagine e domanda.
+Registra la risposta fornita per una determinata immagine e domanda. L'associazione all'utente è automatica e non va specificato `user_id` nel body.
 
 **Request Body**
 ```json
@@ -144,8 +187,10 @@ Registra la risposta fornita da un utente per una determinata immagine e domanda
 
 ## 🎯 ANNOTAZIONI
 
+Richiede autenticazione; le annotazioni vengono collegate all'utente identificato dal token nell'header `Authorization`.
+
 ### `POST /annotations/`
-Salva un’annotazione su un'immagine selezionata (area rettangolare + label).
+Salva un’annotazione su un'immagine selezionata (area rettangolare + label). `user_id` è gestito automaticamente.
 
 **Request Body**
 ```json
@@ -174,7 +219,7 @@ Salva un’annotazione su un'immagine selezionata (area rettangolare + label).
 ```
 
 ### `GET /annotations/{image_id}`
-Restituisce tutte le annotazioni associate a una determinata immagine.
+Restituisce tutte le annotazioni dell'utente autenticato per una determinata immagine.
 
 **Response 200 OK**
 ```json

--- a/docs/Database_Structure.md
+++ b/docs/Database_Structure.md
@@ -2,7 +2,17 @@
 
 ---
 
-## 1. `images`
+## 1. `users`
+
+```sql
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    username TEXT NOT NULL UNIQUE,
+    hashed_password TEXT NOT NULL
+);
+```
+
+## 2. `images`
 
 ```sql
 CREATE TABLE images (
@@ -33,7 +43,7 @@ CREATE TABLE images (
 );
 ```
 
-## 2. `questions`
+## 3. `questions`
 
 ```sql
 CREATE TABLE questions (
@@ -42,7 +52,7 @@ CREATE TABLE questions (
 );
 ```
 
-## 3. `options`
+## 4. `options`
 
 ```sql
 CREATE TABLE options (
@@ -52,7 +62,7 @@ CREATE TABLE options (
 );
 ```
 
-## 4. `answers`
+## 5. `answers`
 
 ```sql
 CREATE TABLE answers (
@@ -60,11 +70,12 @@ CREATE TABLE answers (
     image_id INTEGER NOT NULL REFERENCES images(id),
     question_id INTEGER NOT NULL REFERENCES questions(id),
     selected_option_id INTEGER NOT NULL REFERENCES options(id),
+    user_id INTEGER NOT NULL REFERENCES users(id),
     answered_at TIMESTAMP DEFAULT NOW()
 );
 ```
 
-## 5. `annotations`
+## 6. `annotations`
 
 ```sql
 CREATE TABLE annotations (
@@ -75,6 +86,7 @@ CREATE TABLE annotations (
     y FLOAT NOT NULL,
     width FLOAT NOT NULL,
     height FLOAT NOT NULL,
+    user_id INTEGER NOT NULL REFERENCES users(id),
     annotated_at TIMESTAMP DEFAULT NOW()
 );
 ```


### PR DESCRIPTION
## Summary
- document `users` table and `user_id` fields in answers/annotations schema
- add auth section for registration/login and Authorization header
- clarify that answers and annotations are tied to the authenticated user

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689079fc9c58832a95f11c0f81799bdb