### PR TITLE
Add CRUD endpoints for images

### DIFF
--- a/docs/API_Examples.md
+++ b/docs/API_Examples.md
@@ -19,6 +19,26 @@ curl -X POST http://localhost:8000/images/upload \
   -F "file=@/percorso/della/immagine.jpg"
 ```
 
+### `GET /images/1`
+
+```bash
+curl http://localhost:8000/images/1
+```
+
+### `PUT /images/1`
+
+```bash
+curl -X PUT http://localhost:8000/images/1 \
+  -H "Content-Type: application/json" \
+  -d '{"filename": "nuovo.jpg"}'
+```
+
+### `DELETE /images/1`
+
+```bash
+curl -X DELETE http://localhost:8000/images/1
+```
+
 ---
 
 ## ➕ Creazione di una domanda

--- a/docs/API_REST.md
+++ b/docs/API_REST.md
@@ -83,6 +83,43 @@ file=<binary>
 }
 ```
 
+### `GET /images/{image_id}`
+Restituisce i dettagli di una singola immagine.
+
+**Response 200 OK**
+```json
+{
+  "id": 1,
+  "filename": "immagine1.jpg",
+  "path": "./image_data/immagine1.jpg",
+  "exif_camera_model": "DJI Mavic Air 2"
+}
+```
+
+### `PUT /images/{image_id}`
+Aggiorna i metadati di un’immagine esistente.
+
+**Request Body**
+```json
+{
+  "filename": "nuovo_nome.jpg"
+}
+```
+
+**Response 200 OK**
+```json
+{
+  "id": 1,
+  "filename": "nuovo_nome.jpg",
+  "path": "./image_data/nuovo_nome.jpg"
+}
+```
+
+### `DELETE /images/{image_id}`
+Rimuove un’immagine dal database e dal filesystem.
+
+**Response 204 No Content**
+
 ---
 
 ## ❓ DOMANDE E OPZIONI

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -32,6 +32,30 @@ class ImageDetail(Image):
     exif_yaw: float | None = None
 
 
+class ImageUpdate(BaseModel):
+    filename: str | None = None
+    path: str | None = None
+    exif_datetime: str | None = None
+    exif_gps_lat: float | None = None
+    exif_gps_lon: float | None = None
+    exif_gps_alt: float | None = None
+    exif_camera_make: str | None = None
+    exif_camera_model: str | None = None
+    exif_lens_model: str | None = None
+    exif_focal_length: float | None = None
+    exif_aperture: float | None = None
+    exif_iso: int | None = None
+    exif_shutter_speed: str | None = None
+    exif_orientation: str | None = None
+    exif_image_width: int | None = None
+    exif_image_height: int | None = None
+    exif_drone_model: str | None = None
+    exif_flight_id: str | None = None
+    exif_pitch: float | None = None
+    exif_roll: float | None = None
+    exif_yaw: float | None = None
+
+
 class QuestionBase(BaseModel):
     question_text: str
 


### PR DESCRIPTION
## Summary
- support retrieving, updating and deleting single images via new `/images/{image_id}` endpoints
- document image CRUD operations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68909c6cfe94832a89430254455e2ae1