### PR TITLE
Add Jinja2-based CRUD web UI

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,10 +59,11 @@ def get_current_user(
         raise credentials_exception
     return user
 
-from routers import annotations, answers, images, questions, users
+from routers import annotations, answers, images, questions, users, ui
 
 app.include_router(images.router)
 app.include_router(questions.router)
 app.include_router(answers.router)
 app.include_router(annotations.router)
 app.include_router(users.router)
+app.include_router(ui.router)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ passlib[bcrypt]
 python-jose
 python-multipart
 pillow
+jinja2

--- a/routers/ui.py
+++ b/routers/ui.py
@@ -1,0 +1,334 @@
+from pathlib import Path
+import shutil
+
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, UploadFile, File
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models import (
+    Image as ImageModel,
+    Question as QuestionModel,
+    Option as OptionModel,
+    Answer as AnswerModel,
+    Annotation as AnnotationModel,
+)
+from routers.images import IMAGE_DIR, register_image
+
+templates = Jinja2Templates(directory="templates")
+
+router = APIRouter(prefix="/ui", tags=["ui"], include_in_schema=False)
+
+
+@router.get("/images", response_class=HTMLResponse)
+def list_images(request: Request, db: Session = Depends(get_db)):
+    for file in IMAGE_DIR.iterdir():
+        if file.is_file():
+            register_image(file, db)
+    images = db.query(ImageModel).all()
+    return templates.TemplateResponse("images.html", {"request": request, "images": images})
+
+
+@router.get("/images/upload", response_class=HTMLResponse)
+def upload_image_form(request: Request):
+    return templates.TemplateResponse("image_form.html", {"request": request})
+
+
+@router.post("/images/upload")
+async def upload_image(
+    request: Request,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+):
+    file_path = IMAGE_DIR / file.filename
+    with open(file_path, "wb") as buffer:
+        shutil.copyfileobj(file.file, buffer)
+    register_image(file_path, db)
+    return RedirectResponse(url="/ui/images", status_code=303)
+
+
+@router.get("/images/{image_id}/edit", response_class=HTMLResponse)
+def edit_image_form(image_id: int, request: Request, db: Session = Depends(get_db)):
+    image = db.query(ImageModel).filter_by(id=image_id).first()
+    if not image:
+        raise HTTPException(status_code=404, detail="Image not found")
+    return templates.TemplateResponse(
+        "image_form.html", {"request": request, "image": image}
+    )
+
+
+@router.post("/images/{image_id}/edit")
+def edit_image(image_id: int, filename: str = Form(...), db: Session = Depends(get_db)):
+    image = db.query(ImageModel).filter_by(id=image_id).first()
+    if not image:
+        raise HTTPException(status_code=404, detail="Image not found")
+    image.filename = filename
+    db.commit()
+    return RedirectResponse(url="/ui/images", status_code=303)
+
+
+@router.post("/images/{image_id}/delete")
+def delete_image(image_id: int, db: Session = Depends(get_db)):
+    image = db.query(ImageModel).filter_by(id=image_id).first()
+    if image:
+        file_path = Path(image.path)
+        if file_path.exists():
+            file_path.unlink()
+        db.delete(image)
+        db.commit()
+    return RedirectResponse(url="/ui/images", status_code=303)
+
+
+@router.get("/questions", response_class=HTMLResponse)
+def list_questions(request: Request, db: Session = Depends(get_db)):
+    questions = db.query(QuestionModel).all()
+    return templates.TemplateResponse(
+        "questions.html", {"request": request, "questions": questions}
+    )
+
+
+@router.get("/questions/create", response_class=HTMLResponse)
+def create_question_form(request: Request):
+    return templates.TemplateResponse("question_form.html", {"request": request})
+
+
+@router.post("/questions/create")
+def create_question(question_text: str = Form(...), db: Session = Depends(get_db)):
+    question = QuestionModel(question_text=question_text)
+    db.add(question)
+    db.commit()
+    return RedirectResponse(url="/ui/questions", status_code=303)
+
+
+@router.get("/questions/{question_id}/edit", response_class=HTMLResponse)
+def edit_question_form(question_id: int, request: Request, db: Session = Depends(get_db)):
+    question = db.query(QuestionModel).filter_by(id=question_id).first()
+    if not question:
+        raise HTTPException(status_code=404, detail="Question not found")
+    return templates.TemplateResponse(
+        "question_form.html", {"request": request, "question": question}
+    )
+
+
+@router.post("/questions/{question_id}/edit")
+def edit_question(
+    question_id: int, question_text: str = Form(...), db: Session = Depends(get_db)
+):
+    question = db.query(QuestionModel).filter_by(id=question_id).first()
+    if not question:
+        raise HTTPException(status_code=404, detail="Question not found")
+    question.question_text = question_text
+    db.commit()
+    return RedirectResponse(url="/ui/questions", status_code=303)
+
+
+@router.post("/questions/{question_id}/delete")
+def delete_question(question_id: int, db: Session = Depends(get_db)):
+    question = db.query(QuestionModel).filter_by(id=question_id).first()
+    if question:
+        db.delete(question)
+        db.commit()
+    return RedirectResponse(url="/ui/questions", status_code=303)
+
+
+@router.get("/questions/{question_id}/options/create", response_class=HTMLResponse)
+def create_option_form(question_id: int, request: Request):
+    return templates.TemplateResponse(
+        "option_form.html", {"request": request, "question_id": question_id}
+    )
+
+
+@router.post("/questions/{question_id}/options/create")
+def create_option(
+    question_id: int, option_text: str = Form(...), db: Session = Depends(get_db)
+):
+    option = OptionModel(question_id=question_id, option_text=option_text)
+    db.add(option)
+    db.commit()
+    return RedirectResponse(url="/ui/questions", status_code=303)
+
+
+@router.get("/options/{option_id}/edit", response_class=HTMLResponse)
+def edit_option_form(option_id: int, request: Request, db: Session = Depends(get_db)):
+    option = db.query(OptionModel).filter_by(id=option_id).first()
+    if not option:
+        raise HTTPException(status_code=404, detail="Option not found")
+    return templates.TemplateResponse(
+        "option_form.html", {"request": request, "option": option}
+    )
+
+
+@router.post("/options/{option_id}/edit")
+def edit_option(option_id: int, option_text: str = Form(...), db: Session = Depends(get_db)):
+    option = db.query(OptionModel).filter_by(id=option_id).first()
+    if not option:
+        raise HTTPException(status_code=404, detail="Option not found")
+    option.option_text = option_text
+    db.commit()
+    return RedirectResponse(url="/ui/questions", status_code=303)
+
+
+@router.post("/options/{option_id}/delete")
+def delete_option(option_id: int, db: Session = Depends(get_db)):
+    option = db.query(OptionModel).filter_by(id=option_id).first()
+    if option:
+        db.delete(option)
+        db.commit()
+    return RedirectResponse(url="/ui/questions", status_code=303)
+
+
+@router.get("/answers", response_class=HTMLResponse)
+def list_answers(request: Request, db: Session = Depends(get_db)):
+    answers = db.query(AnswerModel).all()
+    return templates.TemplateResponse(
+        "answers.html", {"request": request, "answers": answers}
+    )
+
+
+@router.get("/answers/create", response_class=HTMLResponse)
+def create_answer_form(request: Request):
+    return templates.TemplateResponse("answer_form.html", {"request": request})
+
+
+@router.post("/answers/create")
+def create_answer(
+    image_id: int = Form(...),
+    question_id: int = Form(...),
+    selected_option_id: int = Form(...),
+    user_id: int = Form(...),
+    db: Session = Depends(get_db),
+):
+    answer = AnswerModel(
+        image_id=image_id,
+        question_id=question_id,
+        selected_option_id=selected_option_id,
+        user_id=user_id,
+    )
+    db.add(answer)
+    db.commit()
+    return RedirectResponse(url="/ui/answers", status_code=303)
+
+
+@router.get("/answers/{answer_id}/edit", response_class=HTMLResponse)
+def edit_answer_form(answer_id: int, request: Request, db: Session = Depends(get_db)):
+    answer = db.query(AnswerModel).filter_by(id=answer_id).first()
+    if not answer:
+        raise HTTPException(status_code=404, detail="Answer not found")
+    return templates.TemplateResponse(
+        "answer_form.html", {"request": request, "answer": answer}
+    )
+
+
+@router.post("/answers/{answer_id}/edit")
+def edit_answer(
+    answer_id: int,
+    image_id: int = Form(...),
+    question_id: int = Form(...),
+    selected_option_id: int = Form(...),
+    user_id: int = Form(...),
+    db: Session = Depends(get_db),
+):
+    answer = db.query(AnswerModel).filter_by(id=answer_id).first()
+    if not answer:
+        raise HTTPException(status_code=404, detail="Answer not found")
+    answer.image_id = image_id
+    answer.question_id = question_id
+    answer.selected_option_id = selected_option_id
+    answer.user_id = user_id
+    db.commit()
+    return RedirectResponse(url="/ui/answers", status_code=303)
+
+
+@router.post("/answers/{answer_id}/delete")
+def delete_answer(answer_id: int, db: Session = Depends(get_db)):
+    answer = db.query(AnswerModel).filter_by(id=answer_id).first()
+    if answer:
+        db.delete(answer)
+        db.commit()
+    return RedirectResponse(url="/ui/answers", status_code=303)
+
+
+@router.get("/annotations", response_class=HTMLResponse)
+def list_annotations(request: Request, db: Session = Depends(get_db)):
+    annotations = db.query(AnnotationModel).all()
+    return templates.TemplateResponse(
+        "annotations.html", {"request": request, "annotations": annotations}
+    )
+
+
+@router.get("/annotations/create", response_class=HTMLResponse)
+def create_annotation_form(request: Request):
+    return templates.TemplateResponse("annotation_form.html", {"request": request})
+
+
+@router.post("/annotations/create")
+def create_annotation(
+    image_id: int = Form(...),
+    label: str = Form(...),
+    x: float = Form(...),
+    y: float = Form(...),
+    width: float = Form(...),
+    height: float = Form(...),
+    user_id: int = Form(...),
+    db: Session = Depends(get_db),
+):
+    annotation = AnnotationModel(
+        image_id=image_id,
+        label=label,
+        x=x,
+        y=y,
+        width=width,
+        height=height,
+        user_id=user_id,
+    )
+    db.add(annotation)
+    db.commit()
+    return RedirectResponse(url="/ui/annotations", status_code=303)
+
+
+@router.get("/annotations/{annotation_id}/edit", response_class=HTMLResponse)
+def edit_annotation_form(
+    annotation_id: int, request: Request, db: Session = Depends(get_db)
+):
+    annotation = db.query(AnnotationModel).filter_by(id=annotation_id).first()
+    if not annotation:
+        raise HTTPException(status_code=404, detail="Annotation not found")
+    return templates.TemplateResponse(
+        "annotation_form.html", {"request": request, "annotation": annotation}
+    )
+
+
+@router.post("/annotations/{annotation_id}/edit")
+def edit_annotation(
+    annotation_id: int,
+    image_id: int = Form(...),
+    label: str = Form(...),
+    x: float = Form(...),
+    y: float = Form(...),
+    width: float = Form(...),
+    height: float = Form(...),
+    user_id: int = Form(...),
+    db: Session = Depends(get_db),
+):
+    annotation = db.query(AnnotationModel).filter_by(id=annotation_id).first()
+    if not annotation:
+        raise HTTPException(status_code=404, detail="Annotation not found")
+    annotation.image_id = image_id
+    annotation.label = label
+    annotation.x = x
+    annotation.y = y
+    annotation.width = width
+    annotation.height = height
+    annotation.user_id = user_id
+    db.commit()
+    return RedirectResponse(url="/ui/annotations", status_code=303)
+
+
+@router.post("/annotations/{annotation_id}/delete")
+def delete_annotation(annotation_id: int, db: Session = Depends(get_db)):
+    annotation = db.query(AnnotationModel).filter_by(id=annotation_id).first()
+    if annotation:
+        db.delete(annotation)
+        db.commit()
+    return RedirectResponse(url="/ui/annotations", status_code=303)

--- a/templates/annotation_form.html
+++ b/templates/annotation_form.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>{% if annotation %}Edit Annotation{% else %}New Annotation{% endif %}</h1>
+<form method="post" action="{% if annotation %}/ui/annotations/{{annotation.id}}/edit{% else %}/ui/annotations/create{% endif %}">
+<label>Image ID: <input type="number" name="image_id" value="{{ annotation.image_id if annotation else '' }}"></label><br>
+<label>Label: <input type="text" name="label" value="{{ annotation.label if annotation else '' }}"></label><br>
+<label>X: <input type="number" step="any" name="x" value="{{ annotation.x if annotation else '' }}"></label><br>
+<label>Y: <input type="number" step="any" name="y" value="{{ annotation.y if annotation else '' }}"></label><br>
+<label>Width: <input type="number" step="any" name="width" value="{{ annotation.width if annotation else '' }}"></label><br>
+<label>Height: <input type="number" step="any" name="height" value="{{ annotation.height if annotation else '' }}"></label><br>
+<label>User ID: <input type="number" name="user_id" value="{{ annotation.user_id if annotation else '' }}"></label><br>
+<button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/annotations.html
+++ b/templates/annotations.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Annotations</h1>
+<a href="/ui/annotations/create">New Annotation</a>
+<table border="1">
+<tr><th>ID</th><th>Image</th><th>Label</th><th>X</th><th>Y</th><th>Width</th><th>Height</th><th>User</th><th>Actions</th></tr>
+{% for an in annotations %}
+<tr>
+<td>{{ an.id }}</td>
+<td>{{ an.image_id }}</td>
+<td>{{ an.label }}</td>
+<td>{{ an.x }}</td>
+<td>{{ an.y }}</td>
+<td>{{ an.width }}</td>
+<td>{{ an.height }}</td>
+<td>{{ an.user_id }}</td>
+<td>
+<a href="/ui/annotations/{{ an.id }}/edit">Edit</a>
+<form method="post" action="/ui/annotations/{{ an.id }}/delete" style="display:inline;">
+<button type="submit">Delete</button>
+</form>
+</td>
+</tr>
+{% endfor %}
+</table>
+{% endblock %}

--- a/templates/answer_form.html
+++ b/templates/answer_form.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>{% if answer %}Edit Answer{% else %}New Answer{% endif %}</h1>
+<form method="post" action="{% if answer %}/ui/answers/{{answer.id}}/edit{% else %}/ui/answers/create{% endif %}">
+<label>Image ID: <input type="number" name="image_id" value="{{ answer.image_id if answer else '' }}"></label><br>
+<label>Question ID: <input type="number" name="question_id" value="{{ answer.question_id if answer else '' }}"></label><br>
+<label>Option ID: <input type="number" name="selected_option_id" value="{{ answer.selected_option_id if answer else '' }}"></label><br>
+<label>User ID: <input type="number" name="user_id" value="{{ answer.user_id if answer else '' }}"></label><br>
+<button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/answers.html
+++ b/templates/answers.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Answers</h1>
+<a href="/ui/answers/create">New Answer</a>
+<table border="1">
+<tr><th>ID</th><th>Image</th><th>Question</th><th>Option</th><th>User</th><th>Actions</th></tr>
+{% for a in answers %}
+<tr>
+<td>{{ a.id }}</td>
+<td>{{ a.image_id }}</td>
+<td>{{ a.question_id }}</td>
+<td>{{ a.selected_option_id }}</td>
+<td>{{ a.user_id }}</td>
+<td>
+<a href="/ui/answers/{{ a.id }}/edit">Edit</a>
+<form method="post" action="/ui/answers/{{ a.id }}/delete" style="display:inline;">
+<button type="submit">Delete</button>
+</form>
+</td>
+</tr>
+{% endfor %}
+</table>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Annotaria</title>
+</head>
+<body>
+<nav>
+    <a href="/ui/images">Images</a> |
+    <a href="/ui/questions">Questions</a> |
+    <a href="/ui/answers">Answers</a> |
+    <a href="/ui/annotations">Annotations</a>
+</nav>
+<hr>
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/image_form.html
+++ b/templates/image_form.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>{% if image %}Edit Image{% else %}Upload Image{% endif %}</h1>
+<form method="post" enctype="multipart/form-data" {% if image %}action="/ui/images/{{ image.id }}/edit"{% else %}action="/ui/images/upload"{% endif %}>
+{% if image %}
+<label>Filename: <input type="text" name="filename" value="{{ image.filename }}"></label><br>
+{% else %}
+<label>File: <input type="file" name="file"></label><br>
+{% endif %}
+<button type="submit">Submit</button>
+</form>
+{% endblock %}

--- a/templates/images.html
+++ b/templates/images.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Images</h1>
+<a href="/ui/images/upload">Upload Image</a>
+<table border="1">
+<tr><th>ID</th><th>Filename</th><th>Actions</th></tr>
+{% for img in images %}
+<tr>
+<td>{{ img.id }}</td>
+<td>{{ img.filename }}</td>
+<td>
+    <a href="/ui/images/{{ img.id }}/edit">Edit</a>
+    <form method="post" action="/ui/images/{{ img.id }}/delete" style="display:inline;">
+        <button type="submit">Delete</button>
+    </form>
+</td>
+</tr>
+{% endfor %}
+</table>
+{% endblock %}

--- a/templates/option_form.html
+++ b/templates/option_form.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>{% if option %}Edit Option{% else %}New Option{% endif %}</h1>
+<form method="post" action="{% if option %}/ui/options/{{option.id}}/edit{% else %}/ui/questions/{{question_id}}/options/create{% endif %}">
+<input type="text" name="option_text" value="{{ option.option_text if option else '' }}">
+<button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/question_form.html
+++ b/templates/question_form.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>{% if question %}Edit Question{% else %}New Question{% endif %}</h1>
+<form method="post" action="{% if question %}/ui/questions/{{question.id}}/edit{% else %}/ui/questions/create{% endif %}">
+<input type="text" name="question_text" value="{{ question.question_text if question else '' }}">
+<button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/questions.html
+++ b/templates/questions.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Questions</h1>
+<a href="/ui/questions/create">New Question</a>
+<ul>
+{% for q in questions %}
+<li>
+{{ q.question_text }}
+<a href="/ui/questions/{{ q.id }}/edit">Edit</a>
+<form method="post" action="/ui/questions/{{ q.id }}/delete" style="display:inline;">
+    <button type="submit">Delete</button>
+</form>
+<ul>
+{% for opt in q.options %}
+<li>{{ opt.option_text }}
+    <a href="/ui/options/{{ opt.id }}/edit">Edit</a>
+    <form method="post" action="/ui/options/{{ opt.id }}/delete" style="display:inline;">
+        <button type="submit">Delete</button>
+    </form>
+</li>
+{% endfor %}
+</ul>
+<a href="/ui/questions/{{ q.id }}/options/create">Add Option</a>
+</li>
+{% endfor %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add FastAPI router for HTML CRUD views of images, questions, answers and annotations
- integrate UI router into application and include Jinja2 dependency
- provide basic Jinja2 templates for listing and editing data

## Testing
- `python -m py_compile routers/ui.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68909dcb89e8832aa4f65b83a984283d