### PR TITLE
style: enhance CRUD UI with Bootstrap

### DIFF
--- a/templates/annotation_form.html
+++ b/templates/annotation_form.html
@@ -2,13 +2,34 @@
 {% block content %}
 <h1>{% if annotation %}Edit Annotation{% else %}New Annotation{% endif %}</h1>
 <form method="post" action="{% if annotation %}/ui/annotations/{{annotation.id}}/edit{% else %}/ui/annotations/create{% endif %}">
-<label>Image ID: <input type="number" name="image_id" value="{{ annotation.image_id if annotation else '' }}"></label><br>
-<label>Label: <input type="text" name="label" value="{{ annotation.label if annotation else '' }}"></label><br>
-<label>X: <input type="number" step="any" name="x" value="{{ annotation.x if annotation else '' }}"></label><br>
-<label>Y: <input type="number" step="any" name="y" value="{{ annotation.y if annotation else '' }}"></label><br>
-<label>Width: <input type="number" step="any" name="width" value="{{ annotation.width if annotation else '' }}"></label><br>
-<label>Height: <input type="number" step="any" name="height" value="{{ annotation.height if annotation else '' }}"></label><br>
-<label>User ID: <input type="number" name="user_id" value="{{ annotation.user_id if annotation else '' }}"></label><br>
-<button type="submit">Save</button>
+<div class="mb-3">
+    <label for="image_id" class="form-label">Image ID</label>
+    <input type="number" class="form-control" id="image_id" name="image_id" value="{{ annotation.image_id if annotation else '' }}">
+</div>
+<div class="mb-3">
+    <label for="label" class="form-label">Label</label>
+    <input type="text" class="form-control" id="label" name="label" value="{{ annotation.label if annotation else '' }}">
+</div>
+<div class="mb-3">
+    <label for="x" class="form-label">X</label>
+    <input type="number" step="any" class="form-control" id="x" name="x" value="{{ annotation.x if annotation else '' }}">
+</div>
+<div class="mb-3">
+    <label for="y" class="form-label">Y</label>
+    <input type="number" step="any" class="form-control" id="y" name="y" value="{{ annotation.y if annotation else '' }}">
+</div>
+<div class="mb-3">
+    <label for="width" class="form-label">Width</label>
+    <input type="number" step="any" class="form-control" id="width" name="width" value="{{ annotation.width if annotation else '' }}">
+</div>
+<div class="mb-3">
+    <label for="height" class="form-label">Height</label>
+    <input type="number" step="any" class="form-control" id="height" name="height" value="{{ annotation.height if annotation else '' }}">
+</div>
+<div class="mb-3">
+    <label for="user_id" class="form-label">User ID</label>
+    <input type="number" class="form-control" id="user_id" name="user_id" value="{{ annotation.user_id if annotation else '' }}">
+</div>
+<button type="submit" class="btn btn-primary">Save</button>
 </form>
 {% endblock %}

--- a/templates/annotations.html
+++ b/templates/annotations.html
@@ -1,9 +1,12 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Annotations</h1>
-<a href="/ui/annotations/create">New Annotation</a>
-<table border="1">
+<a href="/ui/annotations/create" class="btn btn-primary mb-3">New Annotation</a>
+<table class="table table-striped">
+<thead>
 <tr><th>ID</th><th>Image</th><th>Label</th><th>X</th><th>Y</th><th>Width</th><th>Height</th><th>User</th><th>Actions</th></tr>
+</thead>
+<tbody>
 {% for an in annotations %}
 <tr>
 <td>{{ an.id }}</td>
@@ -15,12 +18,13 @@
 <td>{{ an.height }}</td>
 <td>{{ an.user_id }}</td>
 <td>
-<a href="/ui/annotations/{{ an.id }}/edit">Edit</a>
-<form method="post" action="/ui/annotations/{{ an.id }}/delete" style="display:inline;">
-<button type="submit">Delete</button>
+<a href="/ui/annotations/{{ an.id }}/edit" class="btn btn-sm btn-secondary">Edit</a>
+<form method="post" action="/ui/annotations/{{ an.id }}/delete" class="d-inline">
+<button type="submit" class="btn btn-sm btn-danger">Delete</button>
 </form>
 </td>
 </tr>
 {% endfor %}
+</tbody>
 </table>
 {% endblock %}

--- a/templates/answer_form.html
+++ b/templates/answer_form.html
@@ -2,10 +2,22 @@
 {% block content %}
 <h1>{% if answer %}Edit Answer{% else %}New Answer{% endif %}</h1>
 <form method="post" action="{% if answer %}/ui/answers/{{answer.id}}/edit{% else %}/ui/answers/create{% endif %}">
-<label>Image ID: <input type="number" name="image_id" value="{{ answer.image_id if answer else '' }}"></label><br>
-<label>Question ID: <input type="number" name="question_id" value="{{ answer.question_id if answer else '' }}"></label><br>
-<label>Option ID: <input type="number" name="selected_option_id" value="{{ answer.selected_option_id if answer else '' }}"></label><br>
-<label>User ID: <input type="number" name="user_id" value="{{ answer.user_id if answer else '' }}"></label><br>
-<button type="submit">Save</button>
+<div class="mb-3">
+    <label for="image_id" class="form-label">Image ID</label>
+    <input type="number" class="form-control" id="image_id" name="image_id" value="{{ answer.image_id if answer else '' }}">
+</div>
+<div class="mb-3">
+    <label for="question_id" class="form-label">Question ID</label>
+    <input type="number" class="form-control" id="question_id" name="question_id" value="{{ answer.question_id if answer else '' }}">
+</div>
+<div class="mb-3">
+    <label for="selected_option_id" class="form-label">Option ID</label>
+    <input type="number" class="form-control" id="selected_option_id" name="selected_option_id" value="{{ answer.selected_option_id if answer else '' }}">
+</div>
+<div class="mb-3">
+    <label for="user_id" class="form-label">User ID</label>
+    <input type="number" class="form-control" id="user_id" name="user_id" value="{{ answer.user_id if answer else '' }}">
+</div>
+<button type="submit" class="btn btn-primary">Save</button>
 </form>
 {% endblock %}

--- a/templates/answers.html
+++ b/templates/answers.html
@@ -1,9 +1,12 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Answers</h1>
-<a href="/ui/answers/create">New Answer</a>
-<table border="1">
+<a href="/ui/answers/create" class="btn btn-primary mb-3">New Answer</a>
+<table class="table table-striped">
+<thead>
 <tr><th>ID</th><th>Image</th><th>Question</th><th>Option</th><th>User</th><th>Actions</th></tr>
+</thead>
+<tbody>
 {% for a in answers %}
 <tr>
 <td>{{ a.id }}</td>
@@ -12,12 +15,13 @@
 <td>{{ a.selected_option_id }}</td>
 <td>{{ a.user_id }}</td>
 <td>
-<a href="/ui/answers/{{ a.id }}/edit">Edit</a>
-<form method="post" action="/ui/answers/{{ a.id }}/delete" style="display:inline;">
-<button type="submit">Delete</button>
+<a href="/ui/answers/{{ a.id }}/edit" class="btn btn-sm btn-secondary">Edit</a>
+<form method="post" action="/ui/answers/{{ a.id }}/delete" class="d-inline">
+<button type="submit" class="btn btn-sm btn-danger">Delete</button>
 </form>
 </td>
 </tr>
 {% endfor %}
+</tbody>
 </table>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,16 +1,28 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Annotaria</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
-<nav>
-    <a href="/ui/images">Images</a> |
-    <a href="/ui/questions">Questions</a> |
-    <a href="/ui/answers">Answers</a> |
-    <a href="/ui/annotations">Annotations</a>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/">Annotaria</a>
+        <div class="collapse navbar-collapse">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                <li class="nav-item"><a class="nav-link" href="/ui/images">Images</a></li>
+                <li class="nav-item"><a class="nav-link" href="/ui/questions">Questions</a></li>
+                <li class="nav-item"><a class="nav-link" href="/ui/answers">Answers</a></li>
+                <li class="nav-item"><a class="nav-link" href="/ui/annotations">Annotations</a></li>
+            </ul>
+        </div>
+    </div>
 </nav>
-<hr>
+<div class="container">
 {% block content %}{% endblock %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/templates/image_form.html
+++ b/templates/image_form.html
@@ -3,10 +3,16 @@
 <h1>{% if image %}Edit Image{% else %}Upload Image{% endif %}</h1>
 <form method="post" enctype="multipart/form-data" {% if image %}action="/ui/images/{{ image.id }}/edit"{% else %}action="/ui/images/upload"{% endif %}>
 {% if image %}
-<label>Filename: <input type="text" name="filename" value="{{ image.filename }}"></label><br>
+<div class="mb-3">
+    <label for="filename" class="form-label">Filename</label>
+    <input type="text" class="form-control" id="filename" name="filename" value="{{ image.filename }}">
+</div>
 {% else %}
-<label>File: <input type="file" name="file"></label><br>
+<div class="mb-3">
+    <label for="file" class="form-label">File</label>
+    <input type="file" class="form-control" id="file" name="file">
+</div>
 {% endif %}
-<button type="submit">Submit</button>
+<button type="submit" class="btn btn-primary">Submit</button>
 </form>
 {% endblock %}

--- a/templates/images.html
+++ b/templates/images.html
@@ -1,20 +1,24 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Images</h1>
-<a href="/ui/images/upload">Upload Image</a>
-<table border="1">
-<tr><th>ID</th><th>Filename</th><th>Actions</th></tr>
+<a href="/ui/images/upload" class="btn btn-primary mb-3">Upload Image</a>
+<table class="table table-striped">
+<thead>
+    <tr><th>ID</th><th>Filename</th><th>Actions</th></tr>
+</thead>
+<tbody>
 {% for img in images %}
 <tr>
 <td>{{ img.id }}</td>
 <td>{{ img.filename }}</td>
 <td>
-    <a href="/ui/images/{{ img.id }}/edit">Edit</a>
-    <form method="post" action="/ui/images/{{ img.id }}/delete" style="display:inline;">
-        <button type="submit">Delete</button>
+    <a href="/ui/images/{{ img.id }}/edit" class="btn btn-sm btn-secondary">Edit</a>
+    <form method="post" action="/ui/images/{{ img.id }}/delete" class="d-inline">
+        <button type="submit" class="btn btn-sm btn-danger">Delete</button>
     </form>
 </td>
 </tr>
 {% endfor %}
+</tbody>
 </table>
 {% endblock %}

--- a/templates/option_form.html
+++ b/templates/option_form.html
@@ -2,7 +2,10 @@
 {% block content %}
 <h1>{% if option %}Edit Option{% else %}New Option{% endif %}</h1>
 <form method="post" action="{% if option %}/ui/options/{{option.id}}/edit{% else %}/ui/questions/{{question_id}}/options/create{% endif %}">
-<input type="text" name="option_text" value="{{ option.option_text if option else '' }}">
-<button type="submit">Save</button>
+<div class="mb-3">
+    <label for="option_text" class="form-label">Option Text</label>
+    <input type="text" id="option_text" name="option_text" class="form-control" value="{{ option.option_text if option else '' }}">
+</div>
+<button type="submit" class="btn btn-primary">Save</button>
 </form>
 {% endblock %}

--- a/templates/question_form.html
+++ b/templates/question_form.html
@@ -2,7 +2,10 @@
 {% block content %}
 <h1>{% if question %}Edit Question{% else %}New Question{% endif %}</h1>
 <form method="post" action="{% if question %}/ui/questions/{{question.id}}/edit{% else %}/ui/questions/create{% endif %}">
-<input type="text" name="question_text" value="{{ question.question_text if question else '' }}">
-<button type="submit">Save</button>
+<div class="mb-3">
+    <label for="question_text" class="form-label">Question Text</label>
+    <input type="text" id="question_text" name="question_text" class="form-control" value="{{ question.question_text if question else '' }}">
+</div>
+<button type="submit" class="btn btn-primary">Save</button>
 </form>
 {% endblock %}

--- a/templates/questions.html
+++ b/templates/questions.html
@@ -1,26 +1,35 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Questions</h1>
-<a href="/ui/questions/create">New Question</a>
-<ul>
+<a href="/ui/questions/create" class="btn btn-primary mb-3">New Question</a>
+<ul class="list-group">
 {% for q in questions %}
-<li>
-{{ q.question_text }}
-<a href="/ui/questions/{{ q.id }}/edit">Edit</a>
-<form method="post" action="/ui/questions/{{ q.id }}/delete" style="display:inline;">
-    <button type="submit">Delete</button>
-</form>
-<ul>
-{% for opt in q.options %}
-<li>{{ opt.option_text }}
-    <a href="/ui/options/{{ opt.id }}/edit">Edit</a>
-    <form method="post" action="/ui/options/{{ opt.id }}/delete" style="display:inline;">
-        <button type="submit">Delete</button>
-    </form>
-</li>
-{% endfor %}
-</ul>
-<a href="/ui/questions/{{ q.id }}/options/create">Add Option</a>
+<li class="list-group-item">
+<div class="d-flex justify-content-between">
+    <div>
+        {{ q.question_text }}
+        <ul class="list-group mt-2">
+        {% for opt in q.options %}
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+            {{ opt.option_text }}
+            <span>
+                <a href="/ui/options/{{ opt.id }}/edit" class="btn btn-sm btn-secondary">Edit</a>
+                <form method="post" action="/ui/options/{{ opt.id }}/delete" class="d-inline">
+                    <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                </form>
+            </span>
+        </li>
+        {% endfor %}
+        </ul>
+        <a href="/ui/questions/{{ q.id }}/options/create" class="btn btn-sm btn-primary mt-2">Add Option</a>
+    </div>
+    <span>
+        <a href="/ui/questions/{{ q.id }}/edit" class="btn btn-sm btn-secondary">Edit</a>
+        <form method="post" action="/ui/questions/{{ q.id }}/delete" class="d-inline">
+            <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+        </form>
+    </span>
+</div>
 </li>
 {% endfor %}
 </ul>


### PR DESCRIPTION
## Summary
- add Bootstrap layout and navigation
- style forms and CRUD tables for images, questions, answers and annotations

## Testing
- `python -m pytest`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_6890a962034c832a9bb930ef4f44db3b