### PR TITLE
Add CORS middleware with configurable origins

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,17 +2,36 @@ import os
 from datetime import datetime, timedelta
 
 from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
 from passlib.context import CryptContext
+from pydantic import BaseSettings
 from sqlalchemy.orm import Session
 
 from database import Base, engine, get_db
 from models import User as UserModel
 
+
+class AppSettings(BaseSettings):
+    allowed_origins: str = "*"
+
+    class Config:
+        env_file = ".env"
+
+
+settings = AppSettings()
+
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[origin.strip() for origin in settings.allowed_origins.split(",")],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 SECRET_KEY = os.getenv("SECRET_KEY", "secret")
 ALGORITHM = "HS256"


### PR DESCRIPTION
## Summary
- import and configure CORSMiddleware for cross-origin requests
- derive CORS allowed origins from AppSettings (env variable)

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6890b2b97768832aade58260c5505801