### PR TITLE
Add user authentication and interactive image annotation UI

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from fastapi import Depends, FastAPI, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import OAuth2PasswordBearer
+from fastapi.staticfiles import StaticFiles
 from jose import JWTError, jwt
 from passlib.context import CryptContext
 from pydantic import BaseSettings
@@ -79,6 +80,7 @@ def get_current_user(
     return user
 
 from routers import annotations, answers, images, questions, users, ui
+from routers.images import IMAGE_DIR
 
 app.include_router(images.router)
 app.include_router(questions.router)
@@ -86,3 +88,5 @@ app.include_router(answers.router)
 app.include_router(annotations.router)
 app.include_router(users.router)
 app.include_router(ui.router)
+
+app.mount("/image_data", StaticFiles(directory=str(IMAGE_DIR)), name="image_data")

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,6 +17,21 @@
                 <li class="nav-item"><a class="nav-link" href="/ui/answers">Answers</a></li>
                 <li class="nav-item"><a class="nav-link" href="/ui/annotations">Annotations</a></li>
             </ul>
+            <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+                {% if user %}
+                <li class="nav-item">
+                    <span class="navbar-text me-2">Hello, {{ user.username }}</span>
+                </li>
+                <li class="nav-item">
+                    <form action="/ui/logout" method="post" class="d-inline">
+                        <button type="submit" class="btn btn-link nav-link">Logout</button>
+                    </form>
+                </li>
+                {% else %}
+                <li class="nav-item"><a class="nav-link" href="/ui/login">Login</a></li>
+                <li class="nav-item"><a class="nav-link" href="/ui/register">Register</a></li>
+                {% endif %}
+            </ul>
         </div>
     </div>
 </nav>

--- a/templates/image_detail.html
+++ b/templates/image_detail.html
@@ -1,0 +1,105 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>{{ image.filename }}</h1>
+<div id="image-wrapper" style="position:relative; display:inline-block;">
+  <img id="image" src="/image_data/{{ image.filename }}" class="img-fluid" alt="{{ image.filename }}">
+  <canvas id="canvas" style="position:absolute; left:0; top:0;"></canvas>
+</div>
+
+<h2 class="mt-4">Questions</h2>
+<form id="answers-form">
+  {% for q in questions %}
+  <div class="mb-3">
+    <p>{{ q.question_text }}</p>
+    {% for opt in q.options %}
+    <div class="form-check">
+      <input class="form-check-input" type="radio" name="q{{ q.id }}" id="opt{{ opt.id }}" value="{{ opt.id }}">
+      <label class="form-check-label" for="opt{{ opt.id }}">{{ opt.option_text }}</label>
+    </div>
+    {% endfor %}
+  </div>
+  {% endfor %}
+  <button type="submit" class="btn btn-primary">Submit Answers</button>
+</form>
+
+<script>
+const token = "{{ token }}";
+const imageId = {{ image.id }};
+const img = document.getElementById('image');
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+
+function resizeCanvas() {
+  canvas.width = img.clientWidth;
+  canvas.height = img.clientHeight;
+}
+
+img.onload = resizeCanvas;
+window.onresize = resizeCanvas;
+
+let startX, startY, drawing = false;
+canvas.addEventListener('mousedown', e => {
+  startX = e.offsetX;
+  startY = e.offsetY;
+  drawing = true;
+});
+
+canvas.addEventListener('mousemove', e => {
+  if (!drawing) return;
+  const width = e.offsetX - startX;
+  const height = e.offsetY - startY;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.strokeStyle = 'red';
+  ctx.strokeRect(startX, startY, width, height);
+});
+
+canvas.addEventListener('mouseup', e => {
+  if (!drawing) return;
+  drawing = false;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const width = e.offsetX - startX;
+  const height = e.offsetY - startY;
+  const label = prompt('Label for annotation?');
+  if (label) {
+    fetch('/annotations/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        image_id: imageId,
+        label: label,
+        x: startX,
+        y: startY,
+        width: width,
+        height: height
+      })
+    });
+  }
+});
+
+const answersForm = document.getElementById('answers-form');
+answersForm.addEventListener('submit', e => {
+  e.preventDefault();
+  const data = new FormData(answersForm);
+  for (const [key, value] of data.entries()) {
+    const qId = parseInt(key.substring(1));
+    const optionId = parseInt(value);
+    fetch('/answers/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        image_id: imageId,
+        question_id: qId,
+        selected_option_id: optionId
+      })
+    });
+  }
+  alert('Answers submitted');
+});
+</script>
+{% endblock %}

--- a/templates/images.html
+++ b/templates/images.html
@@ -12,6 +12,7 @@
 <td>{{ img.id }}</td>
 <td>{{ img.filename }}</td>
 <td>
+    <a href="/ui/images/{{ img.id }}" class="btn btn-sm btn-primary">View</a>
     <a href="/ui/images/{{ img.id }}/edit" class="btn btn-sm btn-secondary">Edit</a>
     <form method="post" action="/ui/images/{{ img.id }}/delete" class="d-inline">
         <button type="submit" class="btn btn-sm btn-danger">Delete</button>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Login</h1>
+{% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
+<form method="post" action="/ui/login">
+  <div class="mb-3">
+    <label for="username" class="form-label">Username</label>
+    <input type="text" class="form-control" id="username" name="username">
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">Password</label>
+    <input type="password" class="form-control" id="password" name="password">
+  </div>
+  <button type="submit" class="btn btn-primary">Login</button>
+</form>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Register</h1>
+{% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
+<form method="post" action="/ui/register">
+  <div class="mb-3">
+    <label for="username" class="form-label">Username</label>
+    <input type="text" class="form-control" id="username" name="username">
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">Password</label>
+    <input type="password" class="form-control" id="password" name="password">
+  </div>
+  <button type="submit" class="btn btn-primary">Register</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add cookie-based login and registration forms
- Mount image directory and require auth to view image list
- Provide single-image page with canvas annotations and question answering

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890b9c96678832aa84232c842cec842