### PR TITLE
Use pydantic-settings for configuration

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from fastapi.security import OAuth2PasswordBearer
 from fastapi.staticfiles import StaticFiles
 from jose import JWTError, jwt
 from passlib.context import CryptContext
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from sqlalchemy.orm import Session
 
 from database import Base, engine, get_db
@@ -16,9 +16,7 @@ from models import User as UserModel
 
 class AppSettings(BaseSettings):
     allowed_origins: str = "*"
-
-    class Config:
-        env_file = ".env"
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
 
 settings = AppSettings()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-jose
 python-multipart
 pillow
 jinja2
+pydantic-settings


### PR DESCRIPTION
## Summary
- import BaseSettings from pydantic-settings and ignore extra env vars
- add pydantic-settings to requirements

## Testing
- `pytest`
- `timeout 2s uvicorn main:app --port 8000`


------
https://chatgpt.com/codex/tasks/task_e_6890bf289018832a9985716ac8371b23