### PR TITLE
Fix answer updates and remove creation buttons

### DIFF
--- a/routers/answers.py
+++ b/routers/answers.py
@@ -17,8 +17,20 @@ def create_answer(
     db: Session = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
 ):
-    db_answer = AnswerModel(**answer.dict(), user_id=current_user.id)
-    db.add(db_answer)
+    db_answer = (
+        db.query(AnswerModel)
+        .filter_by(
+            image_id=answer.image_id,
+            question_id=answer.question_id,
+            user_id=current_user.id,
+        )
+        .first()
+    )
+    if db_answer:
+        db_answer.selected_option_id = answer.selected_option_id
+    else:
+        db_answer = AnswerModel(**answer.dict(), user_id=current_user.id)
+        db.add(db_answer)
     db.commit()
     db.refresh(db_answer)
     return db_answer

--- a/templates/annotations.html
+++ b/templates/annotations.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Annotations</h1>
-<a href="/ui/annotations/create" class="btn btn-primary mb-3">New Annotation</a>
 <table class="table table-striped">
 <thead>
 <tr><th>ID</th><th>Image</th><th>Label</th><th>X</th><th>Y</th><th>Width</th><th>Height</th><th>User</th><th>Actions</th></tr>

--- a/templates/answers.html
+++ b/templates/answers.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Answers</h1>
-<a href="/ui/answers/create" class="btn btn-primary mb-3">New Answer</a>
 <table class="table table-striped">
 <thead>
 <tr><th>ID</th><th>Image</th><th>Question</th><th>Option</th><th>User</th><th>Actions</th></tr>


### PR DESCRIPTION
## Summary
- remove 'New Answer' and 'New Annotation' buttons from the list views
- update answers in place when resubmitted instead of creating duplicates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890d15f54fc832aafd17d2cb01baf9f