### PR TITLE
Link questions to image types

### DIFF
--- a/models.py
+++ b/models.py
@@ -27,6 +27,24 @@ user_expert_types = Table(
 )
 
 
+question_image_types = Table(
+    "question_image_types",
+    Base.metadata,
+    Column(
+        "question_id",
+        Integer,
+        ForeignKey("questions.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "image_type_id",
+        Integer,
+        ForeignKey("image_types.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+)
+
+
 class User(Base):
     __tablename__ = "users"
 
@@ -58,6 +76,9 @@ class ImageType(Base):
     name = Column(String, unique=True, nullable=False)
 
     images = relationship("Image", back_populates="image_type")
+    questions = relationship(
+        "Question", secondary=question_image_types, back_populates="image_types"
+    )
 
 
 class Image(Base):
@@ -103,6 +124,9 @@ class Question(Base):
 
     options = relationship("Option", back_populates="question")
     answers = relationship("Answer", back_populates="question")
+    image_types = relationship(
+        "ImageType", secondary=question_image_types, back_populates="questions"
+    )
 
 
 class Option(Base):

--- a/routers/questions.py
+++ b/routers/questions.py
@@ -4,7 +4,12 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from database import get_db
-from models import Question as QuestionModel, Option as OptionModel, User as UserModel
+from models import (
+    Question as QuestionModel,
+    Option as OptionModel,
+    User as UserModel,
+    ImageType as ImageTypeModel,
+)
 from main import get_current_user
 from schemas import (
     Question as QuestionSchema,
@@ -29,6 +34,12 @@ def require_admin(current_user: UserModel = Depends(get_current_user)):
 )
 def create_question(question: QuestionCreate, db: Session = Depends(get_db)):
     db_question = QuestionModel(question_text=question.question_text)
+    if question.image_type_ids:
+        db_question.image_types = (
+            db.query(ImageTypeModel)
+            .filter(ImageTypeModel.id.in_(question.image_type_ids))
+            .all()
+        )
     db.add(db_question)
     db.commit()
     db.refresh(db_question)
@@ -47,6 +58,13 @@ def update_question(
     if not db_question:
         raise HTTPException(status_code=404, detail="Question not found")
     db_question.question_text = question.question_text
+    db_question.image_types = (
+        db.query(ImageTypeModel)
+        .filter(ImageTypeModel.id.in_(question.image_type_ids))
+        .all()
+        if question.image_type_ids
+        else []
+    )
     db.commit()
     db.refresh(db_question)
     return db_question

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from pydantic import BaseModel
 
 
@@ -79,11 +81,12 @@ class QuestionBase(BaseModel):
 
 
 class QuestionCreate(QuestionBase):
-    pass
+    image_type_ids: List[int] = []
 
 
 class Question(QuestionBase):
     id: int
+    image_types: List[ImageType] = []
 
     class Config:
         orm_mode = True

--- a/templates/question_form.html
+++ b/templates/question_form.html
@@ -1,11 +1,20 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>{% if question %}Edit Question{% else %}New Question{% endif %}</h1>
-<form method="post" action="{% if question %}/ui/questions/{{question.id}}/edit{% else %}/ui/questions/create{% endif %}">
-<div class="mb-3">
-    <label for="question_text" class="form-label">Question Text</label>
-    <input type="text" id="question_text" name="question_text" class="form-control" value="{{ question.question_text if question else '' }}">
-</div>
-<button type="submit" class="btn btn-primary">Save</button>
+<form method="post"
+      action="{% if question %}/ui/questions/{{question.id}}/edit{% else %}/ui/questions/create{% endif %}">
+  <div class="mb-3">
+      <label for="question_text" class="form-label">Question Text</label>
+      <input type="text" id="question_text" name="question_text" class="form-control" value="{{ question.question_text if question else '' }}">
+  </div>
+  <div class="mb-3">
+      <label for="image_type_ids" class="form-label">Image Types</label>
+      <select id="image_type_ids" name="image_type_ids" class="form-select" multiple>
+      {% for t in image_types %}
+          <option value="{{ t.id }}" {% if question and t in question.image_types %}selected{% endif %}>{{ t.name }}</option>
+      {% endfor %}
+      </select>
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
 </form>
 {% endblock %}

--- a/templates/questions.html
+++ b/templates/questions.html
@@ -8,6 +8,14 @@
 <div class="d-flex justify-content-between">
     <div>
         {{ q.question_text }}
+        {% if q.image_types %}
+        <div class="small text-muted">
+        Image Types:
+        {% for t in q.image_types %}
+            {{ t.name }}{% if not loop.last %}, {% endif %}
+        {% endfor %}
+        </div>
+        {% endif %}
         <ul class="list-group mt-2">
         {% for opt in q.options %}
         <li class="list-group-item d-flex justify-content-between align-items-center">


### PR DESCRIPTION
## Summary
- allow mapping questions to one or more image types with new association table
- expose image type selection when admins create or edit questions and show types in listings
- filter questions by an image's type when viewing the image

## Testing
- `python -m py_compile models.py routers/questions.py routers/ui.py schemas/__init__.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689620783518832ab58fa61acac7ae18