### PR TITLE
Restrict annotations to admin-defined labels

### DIFF
--- a/docs/API_Examples.md
+++ b/docs/API_Examples.md
@@ -90,7 +90,7 @@ curl -X POST http://localhost:8000/annotations/ \
   -H "Content-Type: application/json" \
   -d '{
     "image_id": 1,
-    "label": "malattia fungina",
+    "label_id": 2,
     "x": 120.5,
     "y": 88.0,
     "width": 40.0,

--- a/docs/API_REST.md
+++ b/docs/API_REST.md
@@ -336,14 +336,14 @@ Richiede autenticazione; le annotazioni vengono collegate all'utente identificat
 
 ### `POST /annotations/`
 
-Salva un’annotazione su un'immagine selezionata (area rettangolare + label). `user_id` è gestito automaticamente.
+Salva un’annotazione su un'immagine selezionata (area rettangolare + label predefinita). `user_id` è gestito automaticamente.
 
 **Request Body**
 
 ```json
 {
   "image_id": 1,
-  "label": "foglia danneggiata",
+  "label_id": 2,
   "x": 120.5,
   "y": 80.2,
   "width": 50,
@@ -357,7 +357,8 @@ Salva un’annotazione su un'immagine selezionata (area rettangolare + label). `
 {
   "id": 14,
   "image_id": 1,
-  "label": "foglia danneggiata",
+  "label_id": 2,
+  "label": {"id": 2, "name": "foglia danneggiata"},
   "x": 120.5,
   "y": 80.2,
   "width": 50,
@@ -377,7 +378,8 @@ Restituisce tutte le annotazioni dell'utente autenticato per una determinata imm
   {
     "id": 14,
     "image_id": 1,
-    "label": "foglia danneggiata",
+    "label_id": 2,
+    "label": {"id": 2, "name": "foglia danneggiata"},
     "x": 120.5,
     "y": 80.2,
     "width": 50,
@@ -395,7 +397,7 @@ Aggiorna un'annotazione esistente. Solo i campi forniti nel body vengono modific
 
 ```json
 {
-  "label": "foglia sana",
+  "label_id": 3,
   "x": 130.0
 }
 ```
@@ -406,7 +408,8 @@ Aggiorna un'annotazione esistente. Solo i campi forniti nel body vengono modific
 {
   "id": 14,
   "image_id": 1,
-  "label": "foglia sana",
+  "label_id": 3,
+  "label": {"id": 3, "name": "foglia sana"},
   "x": 130.0,
   "y": 80.2,
   "width": 50,

--- a/docs/Database_Structure.md
+++ b/docs/Database_Structure.md
@@ -93,12 +93,21 @@ CREATE TABLE answers (
 CREATE TABLE annotations (
     id SERIAL PRIMARY KEY,
     image_id INTEGER NOT NULL REFERENCES images(id),
-    label TEXT NOT NULL,
+    label_id INTEGER NOT NULL REFERENCES labels(id),
     x FLOAT NOT NULL,
     y FLOAT NOT NULL,
     width FLOAT NOT NULL,
     height FLOAT NOT NULL,
     user_id INTEGER NOT NULL REFERENCES users(id),
     annotated_at TIMESTAMP DEFAULT NOW()
+);
+```
+
+## 8. `labels`
+
+```sql
+CREATE TABLE labels (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE
 );
 ```

--- a/main.py
+++ b/main.py
@@ -86,7 +86,17 @@ def get_current_user(
         raise credentials_exception
     return user
 
-from routers import annotations, answers, expert_types, image_types, images, questions, users, ui
+from routers import (
+    annotations,
+    answers,
+    expert_types,
+    image_types,
+    images,
+    labels,
+    questions,
+    users,
+    ui,
+)
 from routers.images import IMAGE_DIR
 
 app.include_router(images.router)
@@ -95,6 +105,7 @@ app.include_router(expert_types.router)
 app.include_router(questions.router)
 app.include_router(answers.router)
 app.include_router(annotations.router)
+app.include_router(labels.router)
 app.include_router(users.router)
 app.include_router(ui.router)
 

--- a/models.py
+++ b/models.py
@@ -158,12 +158,21 @@ class Answer(Base):
     user = relationship("User", back_populates="answers")
 
 
+class Label(Base):
+    __tablename__ = "labels"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, nullable=False)
+
+    annotations = relationship("Annotation", back_populates="label")
+
+
 class Annotation(Base):
     __tablename__ = "annotations"
 
     id = Column(Integer, primary_key=True, index=True)
     image_id = Column(Integer, ForeignKey("images.id"), nullable=False)
-    label = Column(String, nullable=False)
+    label_id = Column(Integer, ForeignKey("labels.id"), nullable=False)
     x = Column(Float, nullable=False)
     y = Column(Float, nullable=False)
     width = Column(Float, nullable=False)
@@ -173,3 +182,4 @@ class Annotation(Base):
 
     image = relationship("Image", back_populates="annotations")
     user = relationship("User", back_populates="annotations")
+    label = relationship("Label", back_populates="annotations")

--- a/routers/labels.py
+++ b/routers/labels.py
@@ -1,0 +1,64 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models import Label as LabelModel, User as UserModel
+from schemas import Label as LabelSchema, LabelCreate
+from main import get_current_user
+
+router = APIRouter()
+
+
+def require_admin(current_user: UserModel = Depends(get_current_user)):
+    if current_user.role != "Amministratore":
+        raise HTTPException(status_code=403, detail="Forbidden")
+    return current_user
+
+
+@router.post(
+    "/labels/",
+    response_model=LabelSchema,
+    dependencies=[Depends(require_admin)],
+)
+def create_label(label: LabelCreate, db: Session = Depends(get_db)):
+    db_label = LabelModel(name=label.name)
+    db.add(db_label)
+    db.commit()
+    db.refresh(db_label)
+    return db_label
+
+
+@router.put(
+    "/labels/{label_id}",
+    response_model=LabelSchema,
+    dependencies=[Depends(require_admin)],
+)
+def update_label(label_id: int, label: LabelCreate, db: Session = Depends(get_db)):
+    db_label = db.query(LabelModel).filter_by(id=label_id).first()
+    if not db_label:
+        raise HTTPException(status_code=404, detail="Label not found")
+    db_label.name = label.name
+    db.commit()
+    db.refresh(db_label)
+    return db_label
+
+
+@router.delete(
+    "/labels/{label_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(require_admin)],
+)
+def delete_label(label_id: int, db: Session = Depends(get_db)):
+    db_label = db.query(LabelModel).filter_by(id=label_id).first()
+    if not db_label:
+        raise HTTPException(status_code=404, detail="Label not found")
+    db.delete(db_label)
+    db.commit()
+    return None
+
+
+@router.get("/labels/", response_model=List[LabelSchema])
+def list_labels(db: Session = Depends(get_db)):
+    return db.query(LabelModel).all()

--- a/routers/ui.py
+++ b/routers/ui.py
@@ -17,6 +17,7 @@ from models import (
     Option as OptionModel,
     Answer as AnswerModel,
     Annotation as AnnotationModel,
+    Label as LabelModel,
     User as UserModel,
 )
 from routers.images import IMAGE_DIR, register_image
@@ -252,7 +253,7 @@ def view_image(
 
     annotations = [
         {
-            "label": a.label,
+            "label": a.label.name,
             "x": a.x,
             "y": a.y,
             "width": a.width,
@@ -265,6 +266,8 @@ def view_image(
         )
     ]
 
+    labels = db.query(LabelModel).all()
+
     token = request.cookies.get("access_token")
     return templates.TemplateResponse(
         "image_detail.html",
@@ -276,6 +279,7 @@ def view_image(
             "token": token,
             "answer_map": answer_map,
             "annotations": annotations,
+            "labels": labels,
         },
     )
 
@@ -827,9 +831,11 @@ def list_annotations(
 def create_annotation_form(
     request: Request,
     user: UserModel = Depends(require_admin),
+    db: Session = Depends(get_db),
 ):
+    labels = db.query(LabelModel).all()
     return templates.TemplateResponse(
-        "annotation_form.html", {"request": request, "user": user}
+        "annotation_form.html", {"request": request, "user": user, "labels": labels}
     )
 
 
@@ -839,7 +845,7 @@ def create_annotation_form(
 )
 def create_annotation(
     image_id: int = Form(...),
-    label: str = Form(...),
+    label_id: int = Form(...),
     x: float = Form(...),
     y: float = Form(...),
     width: float = Form(...),
@@ -849,7 +855,7 @@ def create_annotation(
 ):
     annotation = AnnotationModel(
         image_id=image_id,
-        label=label,
+        label_id=label_id,
         x=x,
         y=y,
         width=width,
@@ -874,9 +880,10 @@ def edit_annotation_form(
     annotation = db.query(AnnotationModel).filter_by(id=annotation_id).first()
     if not annotation:
         raise HTTPException(status_code=404, detail="Annotation not found")
+    labels = db.query(LabelModel).all()
     return templates.TemplateResponse(
         "annotation_form.html",
-        {"request": request, "annotation": annotation, "user": user},
+        {"request": request, "annotation": annotation, "user": user, "labels": labels},
     )
 
 
@@ -887,7 +894,7 @@ def edit_annotation_form(
 def edit_annotation(
     annotation_id: int,
     image_id: int = Form(...),
-    label: str = Form(...),
+    label_id: int = Form(...),
     x: float = Form(...),
     y: float = Form(...),
     width: float = Form(...),
@@ -899,7 +906,7 @@ def edit_annotation(
     if not annotation:
         raise HTTPException(status_code=404, detail="Annotation not found")
     annotation.image_id = image_id
-    annotation.label = label
+    annotation.label_id = label_id
     annotation.x = x
     annotation.y = y
     annotation.width = width
@@ -919,3 +926,72 @@ def delete_annotation(annotation_id: int, db: Session = Depends(get_db)):
         db.delete(annotation)
         db.commit()
     return RedirectResponse(url="/ui/annotations", status_code=303)
+
+
+@router.get("/labels", response_class=HTMLResponse)
+def list_labels(
+    request: Request,
+    user: UserModel = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    labels = db.query(LabelModel).all()
+    return templates.TemplateResponse(
+        "labels.html", {"request": request, "labels": labels, "user": user}
+    )
+
+
+@router.get("/labels/create", response_class=HTMLResponse)
+def create_label_form(
+    request: Request,
+    user: UserModel = Depends(require_admin),
+):
+    return templates.TemplateResponse(
+        "label_form.html", {"request": request, "user": user}
+    )
+
+
+@router.post("/labels/create", dependencies=[Depends(require_admin)])
+def create_label(name: str = Form(...), db: Session = Depends(get_db)):
+    label = LabelModel(name=name)
+    db.add(label)
+    db.commit()
+    return RedirectResponse(url="/ui/labels", status_code=303)
+
+
+@router.get("/labels/{label_id}/edit", response_class=HTMLResponse)
+def edit_label_form(
+    label_id: int,
+    request: Request,
+    user: UserModel = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    label = db.query(LabelModel).filter_by(id=label_id).first()
+    if not label:
+        raise HTTPException(status_code=404, detail="Label not found")
+    return templates.TemplateResponse(
+        "label_form.html",
+        {"request": request, "label": label, "user": user},
+    )
+
+
+@router.post("/labels/{label_id}/edit", dependencies=[Depends(require_admin)])
+def edit_label(
+    label_id: int,
+    name: str = Form(...),
+    db: Session = Depends(get_db),
+):
+    label = db.query(LabelModel).filter_by(id=label_id).first()
+    if not label:
+        raise HTTPException(status_code=404, detail="Label not found")
+    label.name = name
+    db.commit()
+    return RedirectResponse(url="/ui/labels", status_code=303)
+
+
+@router.post("/labels/{label_id}/delete", dependencies=[Depends(require_admin)])
+def delete_label(label_id: int, db: Session = Depends(get_db)):
+    label = db.query(LabelModel).filter_by(id=label_id).first()
+    if label:
+        db.delete(label)
+        db.commit()
+    return RedirectResponse(url="/ui/labels", status_code=303)

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -111,3 +111,4 @@ class Option(OptionBase):
 from .answer import Answer, AnswerCreate
 from .annotation import Annotation, AnnotationCreate, AnnotationUpdate
 from .expert_type import ExpertType, ExpertTypeBase, ExpertTypeCreate
+from .label import Label, LabelCreate

--- a/schemas/annotation.py
+++ b/schemas/annotation.py
@@ -1,10 +1,12 @@
 from datetime import datetime
 from pydantic import BaseModel
 
+from .label import Label
+
 
 class AnnotationBase(BaseModel):
     image_id: int
-    label: str
+    label_id: int
     x: float
     y: float
     width: float
@@ -17,7 +19,7 @@ class AnnotationCreate(AnnotationBase):
 
 class AnnotationUpdate(BaseModel):
     image_id: int | None = None
-    label: str | None = None
+    label_id: int | None = None
     x: float | None = None
     y: float | None = None
     width: float | None = None
@@ -28,6 +30,7 @@ class Annotation(AnnotationBase):
     id: int
     user_id: int
     annotated_at: datetime | None = None
+    label: Label
 
     class Config:
         orm_mode = True

--- a/schemas/label.py
+++ b/schemas/label.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+
+
+class LabelBase(BaseModel):
+    name: str
+
+
+class LabelCreate(LabelBase):
+    pass
+
+
+class Label(LabelBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/templates/annotation_form.html
+++ b/templates/annotation_form.html
@@ -7,8 +7,12 @@
     <input type="number" class="form-control" id="image_id" name="image_id" value="{{ annotation.image_id if annotation else '' }}">
 </div>
 <div class="mb-3">
-    <label for="label" class="form-label">Label</label>
-    <input type="text" class="form-control" id="label" name="label" value="{{ annotation.label if annotation else '' }}">
+    <label for="label_id" class="form-label">Label</label>
+    <select class="form-control" id="label_id" name="label_id">
+        {% for l in labels %}
+        <option value="{{ l.id }}" {% if annotation and annotation.label_id == l.id %}selected{% endif %}>{{ l.name }}</option>
+        {% endfor %}
+    </select>
 </div>
 <div class="mb-3">
     <label for="x" class="form-label">X</label>

--- a/templates/annotations.html
+++ b/templates/annotations.html
@@ -10,7 +10,7 @@
 <tr>
 <td>{{ an.id }}</td>
 <td>{{ an.image_id }}</td>
-<td>{{ an.label }}</td>
+<td>{{ an.label.name }}</td>
 <td>{{ an.x }}</td>
 <td>{{ an.y }}</td>
 <td>{{ an.width }}</td>

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,6 +19,7 @@
                 <li class="nav-item"><a class="nav-link" href="/ui/questions">Questions</a></li>
                 <li class="nav-item"><a class="nav-link" href="/ui/answers">Answers</a></li>
                 <li class="nav-item"><a class="nav-link" href="/ui/annotations">Annotations</a></li>
+                <li class="nav-item"><a class="nav-link" href="/ui/labels">Labels</a></li>
                 <li class="nav-item"><a class="nav-link" href="/ui/image-types">Image Types</a></li>
                 <li class="nav-item"><a class="nav-link" href="/ui/expert-types">Expert Types</a></li>
                 {% elif user and user.role == 'Esperto' %}

--- a/templates/image_detail.html
+++ b/templates/image_detail.html
@@ -29,6 +29,7 @@ const img = document.getElementById('image');
 const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 const existingAnnotations = {{ annotations | tojson }};
+const labels = {{ labels | tojson }};
 
 function resizeCanvas() {
   canvas.width = img.clientWidth;
@@ -72,8 +73,10 @@ canvas.addEventListener('mouseup', e => {
   drawAnnotations();
   const width = e.offsetX - startX;
   const height = e.offsetY - startY;
-  const label = prompt('Label for annotation?');
-  if (label) {
+  const labelPrompt = labels.map(l => `${l.id}: ${l.name}`).join('\n');
+  const labelId = parseInt(prompt('Label for annotation?\n' + labelPrompt));
+  const labelObj = labels.find(l => l.id === labelId);
+  if (labelObj) {
     fetch('/annotations/', {
       method: 'POST',
       headers: {
@@ -82,14 +85,14 @@ canvas.addEventListener('mouseup', e => {
       },
       body: JSON.stringify({
         image_id: imageId,
-        label: label,
+        label_id: labelId,
         x: startX,
         y: startY,
         width: width,
         height: height
       })
     }).then(() => {
-      existingAnnotations.push({label: label, x: startX, y: startY, width: width, height: height});
+      existingAnnotations.push({label: labelObj.name, x: startX, y: startY, width: width, height: height});
       drawAnnotations();
     });
   }

--- a/templates/label_form.html
+++ b/templates/label_form.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>{% if label %}Edit Label{% else %}New Label{% endif %}</h1>
+<form method="post" action="{% if label %}/ui/labels/{{ label.id }}/edit{% else %}/ui/labels/create{% endif %}">
+    <div class="mb-3">
+        <label for="name" class="form-label">Name</label>
+        <input type="text" class="form-control" id="name" name="name" value="{{ label.name if label else '' }}" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+</form>
+{% endblock %}

--- a/templates/labels.html
+++ b/templates/labels.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Labels</h1>
+<a href="/ui/labels/create" class="btn btn-primary mb-3">New Label</a>
+<ul class="list-group">
+{% for l in labels %}
+<li class="list-group-item d-flex justify-content-between">
+    {{ l.name }}
+    <span>
+        <a href="/ui/labels/{{ l.id }}/edit" class="btn btn-sm btn-secondary">Edit</a>
+        <form method="post" action="/ui/labels/{{ l.id }}/delete" class="d-inline">
+            <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+        </form>
+    </span>
+</li>
+{% endfor %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Normalize annotation labels into dedicated table
- Require selecting a predefined label when creating annotations
- Add admin UI and API endpoints to manage labels

## Testing
- `python -m py_compile models.py routers/annotations.py routers/labels.py routers/ui.py schemas/label.py schemas/annotation.py main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4517a38f8832ab54ba4eccee171d4