### PR TITLE
Allow linking expert types to image types

### DIFF
--- a/models.py
+++ b/models.py
@@ -45,6 +45,24 @@ question_image_types = Table(
 )
 
 
+expert_type_image_types = Table(
+    "expert_type_image_types",
+    Base.metadata,
+    Column(
+        "expert_type_id",
+        Integer,
+        ForeignKey("expert_types.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "image_type_id",
+        Integer,
+        ForeignKey("image_types.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+)
+
+
 class User(Base):
     __tablename__ = "users"
 
@@ -67,6 +85,9 @@ class ExpertType(Base):
     name = Column(String, unique=True, nullable=False)
 
     users = relationship("User", secondary=user_expert_types, back_populates="expert_types")
+    image_types = relationship(
+        "ImageType", secondary=expert_type_image_types, back_populates="expert_types"
+    )
 
 
 class ImageType(Base):
@@ -78,6 +99,9 @@ class ImageType(Base):
     images = relationship("Image", back_populates="image_type")
     questions = relationship(
         "Question", secondary=question_image_types, back_populates="image_types"
+    )
+    expert_types = relationship(
+        "ExpertType", secondary=expert_type_image_types, back_populates="image_types"
     )
 
 

--- a/routers/ui.py
+++ b/routers/ui.py
@@ -456,9 +456,17 @@ def list_expert_types(
 def create_expert_type_form(
     request: Request,
     user: UserModel = Depends(require_admin),
+    db: Session = Depends(get_db),
 ):
+    image_types = db.query(ImageTypeModel).all()
     return templates.TemplateResponse(
-        "expert_type_form.html", {"request": request, "user": user}
+        "expert_type_form.html",
+        {
+            "request": request,
+            "user": user,
+            "image_types": image_types,
+            "selected_image_type_ids": set(),
+        },
     )
 
 
@@ -468,9 +476,17 @@ def create_expert_type_form(
 )
 def create_expert_type(
     name: str = Form(...),
+    image_type_ids: list[int] = Form([]),
     db: Session = Depends(get_db),
 ):
-    expert_type = ExpertTypeModel(name=name)
+    image_types = (
+        db.query(ImageTypeModel)
+        .filter(ImageTypeModel.id.in_(image_type_ids))
+        .all()
+        if image_type_ids
+        else []
+    )
+    expert_type = ExpertTypeModel(name=name, image_types=image_types)
     db.add(expert_type)
     db.commit()
     return RedirectResponse(url="/ui/expert-types", status_code=303)
@@ -489,9 +505,17 @@ def edit_expert_type_form(
     expert_type = db.query(ExpertTypeModel).filter_by(id=type_id).first()
     if not expert_type:
         raise HTTPException(status_code=404, detail="Expert type not found")
+    image_types = db.query(ImageTypeModel).all()
+    selected_image_type_ids = {t.id for t in expert_type.image_types}
     return templates.TemplateResponse(
         "expert_type_form.html",
-        {"request": request, "expert_type": expert_type, "user": user},
+        {
+            "request": request,
+            "expert_type": expert_type,
+            "user": user,
+            "image_types": image_types,
+            "selected_image_type_ids": selected_image_type_ids,
+        },
     )
 
 
@@ -502,12 +526,21 @@ def edit_expert_type_form(
 def edit_expert_type(
     type_id: int,
     name: str = Form(...),
+    image_type_ids: list[int] = Form([]),
     db: Session = Depends(get_db),
 ):
     expert_type = db.query(ExpertTypeModel).filter_by(id=type_id).first()
     if not expert_type:
         raise HTTPException(status_code=404, detail="Expert type not found")
+    image_types = (
+        db.query(ImageTypeModel)
+        .filter(ImageTypeModel.id.in_(image_type_ids))
+        .all()
+        if image_type_ids
+        else []
+    )
     expert_type.name = name
+    expert_type.image_types = image_types
     db.commit()
     return RedirectResponse(url="/ui/expert-types", status_code=303)
 

--- a/schemas/expert_type.py
+++ b/schemas/expert_type.py
@@ -1,4 +1,7 @@
+from typing import List
+
 from pydantic import BaseModel
+from . import ImageType
 
 
 class ExpertTypeBase(BaseModel):
@@ -6,11 +9,12 @@ class ExpertTypeBase(BaseModel):
 
 
 class ExpertTypeCreate(ExpertTypeBase):
-    pass
+    image_type_ids: List[int] = []
 
 
 class ExpertType(ExpertTypeBase):
     id: int
+    image_types: List[ImageType] = []
 
     class Config:
         orm_mode = True

--- a/templates/expert_type_form.html
+++ b/templates/expert_type_form.html
@@ -6,6 +6,15 @@
         <label for="name" class="form-label">Name</label>
         <input type="text" class="form-control" id="name" name="name" value="{{ expert_type.name if expert_type else '' }}" required>
     </div>
+    <div class="mb-3">
+        <label class="form-label">Image Types</label>
+        {% for t in image_types %}
+        <div class="form-check">
+            <input class="form-check-input" type="checkbox" name="image_type_ids" id="imgtype{{ t.id }}" value="{{ t.id }}" {% if t.id in selected_image_type_ids %}checked{% endif %}>
+            <label class="form-check-label" for="imgtype{{ t.id }}">{{ t.name }}</label>
+        </div>
+        {% endfor %}
+    </div>
     <button type="submit" class="btn btn-primary">Save</button>
 </form>
 {% endblock %}

--- a/templates/expert_types.html
+++ b/templates/expert_types.html
@@ -5,7 +5,12 @@
 <ul class="list-group">
 {% for t in types %}
 <li class="list-group-item d-flex justify-content-between">
-    {{ t.name }}
+    <span>
+        {{ t.name }}
+        {% if t.image_types %}
+            - {{ t.image_types | map(attribute='name') | join(', ') }}
+        {% endif %}
+    </span>
     <span>
         <a href="/ui/expert-types/{{ t.id }}/edit" class="btn btn-sm btn-secondary">Edit</a>
         <form method="post" action="/ui/expert-types/{{ t.id }}/delete" class="d-inline">


### PR DESCRIPTION
## Summary
- Link expert types to image types with a new association table and ORM relationships
- Extend expert type schemas and API/UI logic to manage associated image types
- Update admin templates to select and display related image types

## Testing
- `python -m py_compile models.py routers/expert_types.py routers/ui.py schemas/expert_type.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a471373f2c832aa5eef11c68d87e5d